### PR TITLE
fix typo in CJKPDFReader's ReadMe

### DIFF
--- a/loader_hub/file/cjk_pdf/README.md
+++ b/loader_hub/file/cjk_pdf/README.md
@@ -10,7 +10,7 @@ To use this loader, you need to pass in a `Path` to a local file.
 from pathlib import Path
 from gpt_index import download_loader
 
-PDFReader = download_loader("CJKPDFReader")
+CJKPDFReader = download_loader("CJKPDFReader")
 
 loader = CJKPDFReader()
 documents = loader.load_data(file=Path('./article.pdf'))


### PR DESCRIPTION
I fixed typo in example code in CJKPDFParser’s ReadMe. I changed “PDFReader” to “CJKPDFReader” on line 4.