### PR TITLE
Update for MongoDB Atlast

### DIFF
--- a/loader_hub/mongo/base.py
+++ b/loader_hub/mongo/base.py
@@ -17,7 +17,7 @@ class SimpleMongoReader(BaseReader):
 
     """
 
-    def __init__(self, host: str, port: int, mongo_db_url: Optional[Dict] = None  max_docs: int = 1000) -> None:
+    def __init__(self, host: str, port: int, mongo_db_url: Optional[Dict] = None, max_docs: int = 1000) -> None:
         """Initialize with parameters."""
         from pymongo import MongoClient  # noqa: F401
 

--- a/loader_hub/mongo/base.py
+++ b/loader_hub/mongo/base.py
@@ -17,11 +17,14 @@ class SimpleMongoReader(BaseReader):
 
     """
 
-    def __init__(self, mongo_db_url: str, max_docs: int = 1000) -> None:
+    def __init__(self, host: str, port: int, mongo_db_url: Optional[Dict] = None  max_docs: int = 1000) -> None:
         """Initialize with parameters."""
         from pymongo import MongoClient  # noqa: F401
 
-        self.client: MongoClient = MongoClient(mongo_db_url)
+        if mongo_db_url is not None:
+            self.client: MongoClient = MongoClient(mongo_db_url)
+        else:
+            self.client: MongoClient = MongoClient(host, port)
         self.max_docs = max_docs
 
     def load_data(

--- a/loader_hub/mongo/base.py
+++ b/loader_hub/mongo/base.py
@@ -12,17 +12,16 @@ class SimpleMongoReader(BaseReader):
     Concatenates each Mongo doc into Document used by LlamaIndex.
 
     Args:
-        host (str): Mongo host.
-        port (int): Mongo port.
+        mongo_db_url (str): Mongo Full URL.
         max_docs (int): Maximum number of documents to load.
 
     """
 
-    def __init__(self, host: str, port: int, max_docs: int = 1000) -> None:
+    def __init__(self, mongo_db_url: str, max_docs: int = 1000) -> None:
         """Initialize with parameters."""
         from pymongo import MongoClient  # noqa: F401
 
-        self.client: MongoClient = MongoClient(host, port)
+        self.client: MongoClient = MongoClient(mongo_db_url)
         self.max_docs = max_docs
 
     def load_data(


### PR DESCRIPTION
Previously class took `host` and `port` as a parameter. Connect with MongoDB Atlas it's not possible to provide the host and port as it has a single URL. So directly pass the URL to the MongoClient.