### PR TITLE
[Google Docs Reader] Update base.py

### DIFF
--- a/loader_hub/google_docs/base.py
+++ b/loader_hub/google_docs/base.py
@@ -88,7 +88,7 @@ class GoogleDocsReader(BaseReader):
                 flow = InstalledAppFlow.from_client_secrets_file(
                     "credentials.json", SCOPES
                 )
-                creds = flow.run_local_server(port=0)
+                creds = flow.run_local_server(port=8080)
             # Save the credentials for the next run
             with open("token.json", "w") as token:
                 token.write(creds.to_json())


### PR DESCRIPTION
When the port is set to `0`, the URI is randomized every time the code is used. This makes it difficult to register a specific URI with `OAuth 2.0 Client`. Fixing the port resolves this. You can now add the following to `Authorized redirect URIs`: `http://localhost:8080/`