### PR TITLE
Added domain lock paramater

### DIFF
--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -39,9 +39,7 @@ class RemoteDepthReader(BaseReader):
             urls[i] = []
             new_links = []
             print(f"Reading links at depth {i}...")
-
             for link in tqdm(links):
-                print(link)
                 """Checking if the link belongs the provided domain. """
                 if ((self.domain_lock and link>url) or (not self.domain_lock)):
                     print("Loading link: " + link)
@@ -51,6 +49,8 @@ class RemoteDepthReader(BaseReader):
                         urls[i].append(link)
                         new_links.extend(self.get_links(link))
                     links_visited.append(link)
+                else:
+                    print("Link ignored: " +link)
             new_links = list(set(new_links))
             links = new_links
         print(f"Found {len(urls)} links at depth {self.depth}.")

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -25,7 +25,7 @@ class RemoteDepthReader(BaseReader):
         self.file_extractor = file_extractor
         self.depth = depth
         print("***** I am loading *****")
-        print(domain_lock)
+        print(str(domain_lock))
 
     def load_data(self, url: str) -> List[Document]:
         from tqdm.auto import tqdm

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -41,6 +41,7 @@ class RemoteDepthReader(BaseReader):
             urls[i] = []
             new_links = []
             print(f"Reading links at depth {i}...")
+
             for link in tqdm(links):
                 print(link)
                 print(url)

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -16,17 +16,19 @@ class RemoteDepthReader(BaseReader):
         *args: Any,
         file_extractor: Optional[Dict[str, Union[str, BaseReader]]] = None,
         depth: int = 1,
+        domain_lock: bool=False,
         **kwargs: Any,
     ) -> None:
         """Init params."""
         super().__init__(*args, **kwargs)
         self.file_extractor = file_extractor
         self.depth = depth
+        self.domain_lock = domain_lock
 
-    def load_data(self, url: str, domain_lock: bool=False) -> List[Document]:
+    def load_data(self, url: str) -> List[Document]:
         from tqdm.auto import tqdm
         print("***** I am loading *****")
-        print(str(domain_lock))
+        print(str(self.domain_lock))
 
         """Parse whatever is at the URL.""" ""
         RemoteReader = download_loader("RemoteReader")

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -43,7 +43,7 @@ class RemoteDepthReader(BaseReader):
             for link in tqdm(links):
                 print(link)
                 """Checking if the link belongs the provided domain. """
-                if (domain_lock and link>url):
+                if ((self.domain_lock and link>url) or (not self.domain_lock)):
                     print("Loading link: " + link)
                     if link in links_visited:
                         continue

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -40,10 +40,11 @@ class RemoteDepthReader(BaseReader):
         for i in range(self.depth + 1):
             urls[i] = []
             new_links = []
-            print(f"Reading linkss at depth {i}...")
+            print(f"Reading links at depth {i}...")
             for link in tqdm(links):]
                 print(link)
-                pprint(url)
+                print(url)
+                """Checking if the link belongs the provided domain """
                 if (self.domainlock && link>url):
                     if link in links_visited:
                         continue

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -38,7 +38,7 @@ class RemoteDepthReader(BaseReader):
         for i in range(self.depth + 1):
             urls[i] = []
             new_links = []
-            print(f"Reading links at depth {i}...")
+            print(f"Reading linkss at depth {i}...")
             for link in tqdm(links):
                 if link in links_visited:
                     continue

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -46,7 +46,7 @@ class RemoteDepthReader(BaseReader):
                 print(link)
                 print(url)
                 """Checking if the link belongs the provided domain. """
-                if (self.domainlock && link>url):
+                if (self.domainlock and link>url):
                     if link in links_visited:
                         continue
                     if link:

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -44,7 +44,7 @@ class RemoteDepthReader(BaseReader):
                 print(link)
                 print(url)
                 """Checking if the link belongs the provided domain. """
-                if (self.domain_lock and link>url):
+                if (domain_lock and link>url):
                     if link in links_visited:
                         continue
                     if link:

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -16,7 +16,7 @@ class RemoteDepthReader(BaseReader):
         *args: Any,
         file_extractor: Optional[Dict[str, Union[str, BaseReader]]] = None,
         depth: int = 1,
-        domain_lock: bool=False,
+        domain_lock: bool = False,
         **kwargs: Any,
     ) -> None:
         """Init params."""

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -24,7 +24,8 @@ class RemoteDepthReader(BaseReader):
 
         self.file_extractor = file_extractor
         self.depth = depth
-        print("***** I am loading *****" + domain_lock)
+        print("***** I am loading *****")
+        print(domain_lock)
 
     def load_data(self, url: str) -> List[Document]:
         from tqdm.auto import tqdm

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -27,8 +27,6 @@ class RemoteDepthReader(BaseReader):
 
     def load_data(self, url: str) -> List[Document]:
         from tqdm.auto import tqdm
-        print("***** I am loading *****")
-        print(str(self.domain_lock))
 
         """Parse whatever is at the URL.""" ""
         RemoteReader = download_loader("RemoteReader")

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -45,6 +45,7 @@ class RemoteDepthReader(BaseReader):
                 print(url)
                 """Checking if the link belongs the provided domain. """
                 if (domain_lock and link>url):
+                    print("Loading link: " + link)
                     if link in links_visited:
                         continue
                     if link:

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -20,10 +20,8 @@ class RemoteDepthReader(BaseReader):
     ) -> None:
         """Init params."""
         super().__init__(*args, **kwargs)
-
         self.file_extractor = file_extractor
         self.depth = depth
-        self.domain_lock = domain_lock
 
     def load_data(self, url: str, domain_lock: bool=False) -> List[Document]:
         from tqdm.auto import tqdm

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -16,7 +16,6 @@ class RemoteDepthReader(BaseReader):
         *args: Any,
         file_extractor: Optional[Dict[str, Union[str, BaseReader]]] = None,
         depth: int = 1,
-        domain_lock: bool = False,
         **kwargs: Any,
     ) -> None:
         """Init params."""
@@ -25,11 +24,11 @@ class RemoteDepthReader(BaseReader):
         self.file_extractor = file_extractor
         self.depth = depth
         self.domain_lock = domain_lock
+
+    def load_data(self, url: str, domain_lock: bool=False) -> List[Document]:
+        from tqdm.auto import tqdm
         print("***** I am loading *****")
         print(str(domain_lock))
-
-    def load_data(self, url: str) -> List[Document]:
-        from tqdm.auto import tqdm
 
         """Parse whatever is at the URL.""" ""
         RemoteReader = download_loader("RemoteReader")

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -46,7 +46,7 @@ class RemoteDepthReader(BaseReader):
                 print(link)
                 print(url)
                 """Checking if the link belongs the provided domain. """
-                if (self.domainlock and link>url):
+                if (self.domain_lock and link>url):
                     if link in links_visited:
                         continue
                     if link:

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -41,7 +41,7 @@ class RemoteDepthReader(BaseReader):
             urls[i] = []
             new_links = []
             print(f"Reading links at depth {i}...")
-            for link in tqdm(links):]
+            for link in tqdm(links):
                 print(link)
                 print(url)
                 """Checking if the link belongs the provided domain """

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -24,6 +24,7 @@ class RemoteDepthReader(BaseReader):
 
         self.file_extractor = file_extractor
         self.depth = depth
+        self.domain_lock = domain_lock
         print("***** I am loading *****")
         print(str(domain_lock))
 

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -41,13 +41,16 @@ class RemoteDepthReader(BaseReader):
             urls[i] = []
             new_links = []
             print(f"Reading linkss at depth {i}...")
-            for link in tqdm(links):
-                if link in links_visited:
-                    continue
-                if link:
-                    urls[i].append(link)
-                    new_links.extend(self.get_links(link))
-                links_visited.append(link)
+            for link in tqdm(links):]
+                print(link)
+                pprint(url)
+                if (self.domainlock && link>url):
+                    if link in links_visited:
+                        continue
+                    if link:
+                        urls[i].append(link)
+                        new_links.extend(self.get_links(link))
+                    links_visited.append(link)
             new_links = list(set(new_links))
             links = new_links
         print(f"Found {len(urls)} links at depth {self.depth}.")

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -16,6 +16,7 @@ class RemoteDepthReader(BaseReader):
         *args: Any,
         file_extractor: Optional[Dict[str, Union[str, BaseReader]]] = None,
         depth: int = 1,
+        domain_lock: bool = True,
         **kwargs: Any,
     ) -> None:
         """Init params."""
@@ -23,7 +24,7 @@ class RemoteDepthReader(BaseReader):
 
         self.file_extractor = file_extractor
         self.depth = depth
-        print("***** I am loading *****")
+        print("***** I am loading *****" + domain_lock)
 
     def load_data(self, url: str) -> List[Document]:
         from tqdm.auto import tqdm

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -44,7 +44,7 @@ class RemoteDepthReader(BaseReader):
             for link in tqdm(links):
                 print(link)
                 print(url)
-                """Checking if the link belongs the provided domain """
+                """Checking if the link belongs the provided domain. """
                 if (self.domainlock && link>url):
                     if link in links_visited:
                         continue

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -23,6 +23,7 @@ class RemoteDepthReader(BaseReader):
 
         self.file_extractor = file_extractor
         self.depth = depth
+        print("***** I am loading *****")
 
     def load_data(self, url: str) -> List[Document]:
         from tqdm.auto import tqdm

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -16,7 +16,7 @@ class RemoteDepthReader(BaseReader):
         *args: Any,
         file_extractor: Optional[Dict[str, Union[str, BaseReader]]] = None,
         depth: int = 1,
-        domain_lock: bool = True,
+        domain_lock: bool = False,
         **kwargs: Any,
     ) -> None:
         """Init params."""

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -42,7 +42,6 @@ class RemoteDepthReader(BaseReader):
 
             for link in tqdm(links):
                 print(link)
-                print(url)
                 """Checking if the link belongs the provided domain. """
                 if (domain_lock and link>url):
                     print("Loading link: " + link)

--- a/loader_hub/remote_depth/base.py
+++ b/loader_hub/remote_depth/base.py
@@ -41,7 +41,7 @@ class RemoteDepthReader(BaseReader):
             print(f"Reading links at depth {i}...")
             for link in tqdm(links):
                 """Checking if the link belongs the provided domain. """
-                if ((self.domain_lock and link>url) or (not self.domain_lock)):
+                if ((self.domain_lock and link.find(url)>-1) or (not self.domain_lock)):
                     print("Loading link: " + link)
                     if link in links_visited:
                         continue


### PR DESCRIPTION
Existing code will follow any link it finds, regardless of where it goes. Now if domain_lock is TRUE, it will only index pages on the provided domain. EG if your domain is https://www.test.com, and it finds a link to https://www.test2.com, it will be discarded of domain_lock is true. Its optional and defaults to FALSE, so non-breaking change.

