### PR TITLE
Bug fix for Slack reader

### DIFF
--- a/loader_hub/slack/base.py
+++ b/loader_hub/slack/base.py
@@ -55,6 +55,8 @@ class SlackReader(BaseReader):
                 self.latest_date_timestamp = latest_date.timestamp()
             else:
                 self.latest_date_timestamp = datetime.now().timestamp()
+        else:
+            self.earliest_date_timestamp = None
         res = self.client.api_test()
         if not res["ok"]:
             raise ValueError(f"Error initializing Slack API: {res['error']}")


### PR DESCRIPTION
To resolve the following error message:
`AttributeError: 'SlackReader' object has no attribute 'earliest_date_timestamp'`

Error is caused by:
https://github.com/emptycrown/llama-hub/blob/e670547a925a749c8269af824c70fc7c1445029f/loader_hub/slack/base.py#L75