### PR TITLE
Iterative Parser for Gmail

### DIFF
--- a/loader_hub/gmail/base.py
+++ b/loader_hub/gmail/base.py
@@ -19,7 +19,7 @@ class GmailReader(BaseReader, BaseModel):
         max_results (int): Max number of results. Defaults to 10.
     """
     query: str = None
-    use_iterative_parser: bool = False
+    use_iterative_parser: bool = True
     max_results: int = 10
     service: Any
 


### PR DESCRIPTION
Enabling iterative parser as default option for Gmail reader. I have tested it many times and I think it works better than current default method.