### PR TITLE
Add locale settings for Zendesk loader

### DIFF
--- a/loader_hub/zendesk/README.md
+++ b/loader_hub/zendesk/README.md
@@ -4,14 +4,14 @@ This loader fetches the text from Zendesk help articles using the Zendesk API. I
 
 ## Usage
 
-To use this loader, you need to pass in the subdomain of a Zendesk account. No authentication is required.
+To use this loader, you need to pass in the subdomain of a Zendesk account. No authentication is required. You can also set the locale of articles as needed.
 
 ```python
 from llama_index import download_loader
 
 ZendeskReader = download_loader("ZendeskReader")
 
-loader = ZendeskReader(zendesk_subdomain="my_subdomain")
+loader = ZendeskReader(zendesk_subdomain="my_subdomain", locale="en-us")
 documents = loader.load_data()
 ```
 

--- a/loader_hub/zendesk/base.py
+++ b/loader_hub/zendesk/base.py
@@ -11,11 +11,13 @@ class ZendeskReader(BaseReader):
 
     Args:
         zendesk_subdomain (str): Zendesk subdomain
+        locale (str): Locale of articles
     """
 
-    def __init__(self, zendesk_subdomain: str) -> None:
+    def __init__(self, zendesk_subdomain: str, locale: str = "en-us") -> None:
         """Initialize Zendesk reader."""
         self.zendesk_subdomain = zendesk_subdomain
+        self.locale = locale
 
     def load_data(self) -> List[Document]:
         """Load data from the workspace.
@@ -68,7 +70,7 @@ class ZendeskReader(BaseReader):
         import requests
 
         if next_page is None:
-            url = f"https://{self.zendesk_subdomain}.zendesk.com/api/v2/help_center/en-us/articles?per_page=100"
+            url = f"https://{self.zendesk_subdomain}.zendesk.com/api/v2/help_center/{self.locale}/articles?per_page=100"
         else:
             url = next_page
 


### PR DESCRIPTION
The Zendesk loader uses the [articles API](https://developer.zendesk.com/api-reference/help_center/help-center-api/articles/#list-articles). This API allows specifying the locale as a parameter. This pull request corresponds to that locale setting.