### PR TITLE
Rename JSONReader.load_data input_file param to file to match other file reader load_data signatures

### DIFF
--- a/loader_hub/file/json/base.py
+++ b/loader_hub/file/json/base.py
@@ -52,14 +52,14 @@ class JSONReader(BaseReader):
 
     def load_data(
         self, 
-        input_file: Path, 
+        file: Path, 
         extra_info: Optional[Dict] = None
     ) -> List[Document]:
         """Load data from the input file."""
-        # TODO: change Path typing for input_file in all load_data calls
-        if not isinstance(input_file, Path):
-            input_file = Path(input_file)
-        with open(input_file, "r") as f:
+        # TODO: change Path typing for file in all load_data calls
+        if not isinstance(file, Path):
+            file = Path(file)
+        with open(file, "r") as f:
             data = json.load(f)
             if self.levels_back is None:
                 # If levels_back isn't set, we just format and make each


### PR DESCRIPTION
Currently, when JSONReader gets invoked by `SimpleDirectoryReader`, it results in the following error:
```
JSONReader.load_data() got an unexpected keyword argument 'file'
```

This is due to the `file` param not being present in `JSONReader.load_data`. This fix makes the reader's `load_data` function signature consistent with the other file readers.