### PR TITLE
Extend S3Reader

### DIFF
--- a/loader_hub/s3/base.py
+++ b/loader_hub/s3/base.py
@@ -24,6 +24,7 @@ class S3Reader(BaseReader):
         file_extractor: Optional[Dict[str, Union[str, BaseReader]]] = None,
         aws_access_id: Optional[str] = None,
         aws_access_secret: Optional[str] = None,
+        s3_endpoint_url: Optional[str] = "https://s3.amazonaws.com",
         **kwargs: Any,
     ) -> None:
         """Initialize S3 bucket and key, along with credentials if needed.
@@ -52,6 +53,7 @@ class S3Reader(BaseReader):
 
         self.aws_access_id = aws_access_id
         self.aws_access_secret = aws_access_secret
+        self.s3_endpoint_url = s3_endpoint_url
 
     def load_data(self) -> List[Document]:
         """Load file(s) from S3."""
@@ -65,7 +67,7 @@ class S3Reader(BaseReader):
                 aws_secret_access_key=self.aws_access_secret,
             )
             s3 = session.resource("s3")
-            s3_client = session.client("s3")
+            s3_client = session.client("s3", endpoint_url=self.s3_url)
 
         with tempfile.TemporaryDirectory() as temp_dir:
             if self.key:

--- a/loader_hub/s3/base.py
+++ b/loader_hub/s3/base.py
@@ -42,6 +42,7 @@ class S3Reader(BaseReader):
             to text. See `SimpleDirectoryReader` for more details.
         aws_access_id (Optional[str]): provide AWS access key directly.
         aws_access_secret (Optional[str]): provide AWS access key directly.
+        s3_endpoint_url (Optional[str]): provide S3 endpoint URL directly.
         """
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
Other cloud providers, such as Linode & DigitalOcean conform to the S3 Api.
This PR adds the ability to select the url to which requests should be sent instead of just to S3.
