### PR TITLE
utf-8 encoding fixes UnicodeDecodeError

### DIFF
--- a/loader_hub/file/simple_csv/base.py
+++ b/loader_hub/file/simple_csv/base.py
@@ -32,7 +32,7 @@ class SimpleCSVReader(BaseReader):
         import csv
 
         text_list = []
-        with open(file, "r") as fp:
+        with open(file, "r", encoding='utf-8') as fp:
             csv_reader = csv.reader(fp)
             for row in csv_reader:
                 text_list.append(", ".join(row))


### PR DESCRIPTION
Opening the file with encoding = 'utf-8', fixes the following UnicodeDecodeError UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 1094: character maps to

OS: Windows 10 x64