### PR TITLE
Update slack reader

### DIFF
--- a/loader_hub/slack/base.py
+++ b/loader_hub/slack/base.py
@@ -116,10 +116,18 @@ class SlackReader(BaseReader):
                 # conversations.history returns the first 100 messages by default
                 # These results are paginated,
                 # see: https://api.slack.com/methods/conversations.history$pagination
-                result = self.client.conversations_history(
-                    channel=channel_id,
-                    cursor=next_cursor,
-                )
+                if self.earliest_date_timestamp is None:
+                    result = self.client.conversations_history(
+                        channel=channel_id,
+                        cursor=next_cursor,
+                    )
+                else:
+                    result = self.client.conversations_history(
+                        channel=channel_id,
+                        cursor=next_cursor,
+                        oldest=str(self.earliest_date_timestamp),
+                        latest=str(self.latest_date_timestamp),
+                    )                    
                 conversation_history = result["messages"]
                 # Print results
                 logger.info(


### PR DESCRIPTION
Hi,

I have updated the Slack reader due to issues encountered while retrieving messages using the earliest and latest dates. Specifically, I found that errors were occurring because the `conversation_history` did not include these dates. Therefore, we have made changes to address this issue.

Thank you.