### PR TITLE
Update pandas_excel loader

### DIFF
--- a/loader_hub/file/pandas_excel/README.md
+++ b/loader_hub/file/pandas_excel/README.md
@@ -4,8 +4,7 @@ This loader extracts the text from a column of a local .xlsx file using the `pan
 
 ## Usage
 
-To use this loader, you need to pass in a `Path` to a local file, along with a `sheet_name` from which sheet to extract data. You can set `sheet_name=None`, which means it will load all the sheets in the excel file. You can set `sheet_name="Data1` to load only the sheet named "Data1". Or you can set `sheet_name=0` to load the first sheet in the excel file.
-
+To use this loader, you need to pass in a `Path` to a local file, along with a `sheet_name` from which sheet to extract data. The default `sheet_name=None`, which means it will load all the sheets in the excel file. You can set `sheet_name="Data1` to load only the sheet named "Data1". Or you can set `sheet_name=0` to load the first sheet in the excel file. You can pass any additional pandas configuration options to the `pandas_config` parameter, please see the [pandas documentation](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_excel.html).
 
 ```python
 from pathlib import Path
@@ -14,7 +13,7 @@ from llama_index import download_loader
 PandasExcelReader = download_loader("PandasExcelReader")
 
 loader = PandasExcelReader()
-documents = loader.load_data(file=Path('./data.xlsx'), sheet_name=None, pandas_config={"sheet_name":"Sheet1"})
+documents = loader.load_data(file=Path('./data.xlsx'), pandas_config={"header":0})
 ```
 
 This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/jerryjliu/gpt_index/tree/main/gpt_index) and/or subsequently used as a Tool in a [LangChain](https://github.com/hwchase17/langchain) Agent. See [here](https://github.com/emptycrown/llama-hub/tree/main) for examples.

--- a/loader_hub/file/pandas_excel/README.md
+++ b/loader_hub/file/pandas_excel/README.md
@@ -4,7 +4,7 @@ This loader extracts the text from a column of a local .xlsx file using the `pan
 
 ## Usage
 
-To use this loader, you need to pass in a `Path` to a local file, along with a `column_name` from where to extract data.
+To use this loader, you need to pass in a `Path` to a local file, along with a `sheet_name` from which sheet to extract data. You can set `sheet_name=None`, which means it will load all the sheets in the excel file. You can set `sheet_name="Data1` to load only the sheet named "Data1". Or you can set `sheet_name=0` to load the first sheet in the excel file.
 
 
 ```python
@@ -14,7 +14,7 @@ from llama_index import download_loader
 PandasExcelReader = download_loader("PandasExcelReader")
 
 loader = PandasExcelReader()
-documents = loader.load_data(file=Path('./data.xlsx'), column_name="text_column",pandas_config={"sheet_name":"Sheet1"})
+documents = loader.load_data(file=Path('./data.xlsx'), sheet_name=None, pandas_config={"sheet_name":"Sheet1"})
 ```
 
 This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/jerryjliu/gpt_index/tree/main/gpt_index) and/or subsequently used as a Tool in a [LangChain](https://github.com/hwchase17/langchain) Agent. See [here](https://github.com/emptycrown/llama-hub/tree/main) for examples.

--- a/loader_hub/file/pandas_excel/base.py
+++ b/loader_hub/file/pandas_excel/base.py
@@ -35,7 +35,7 @@ class PandasExcelReader(BaseReader):
         self._pandas_config = pandas_config
 
     def load_data(
-        self, file: Path, extra_info: Optional[Dict] = None
+        self, file: Path, sheet_name: str | int | None = None, extra_info: Optional[Dict] = None
     ) -> List[Document]:
         """Parse file and extract values from a specific column.
 
@@ -48,8 +48,8 @@ class PandasExcelReader(BaseReader):
         import itertools
 
         import pandas as pd
-
-        df = pd.read_excel(file, sheet_name=None, **self._pandas_config)
+        
+        df = pd.read_excel(file, sheet_name=sheet_name, **self._pandas_config)
 
         keys = df.keys()
 

--- a/loader_hub/file/pandas_excel/base.py
+++ b/loader_hub/file/pandas_excel/base.py
@@ -4,7 +4,7 @@ Pandas parser for .xlsx files.
 
 """
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from llama_index.readers.base import BaseReader
 from llama_index.readers.schema.base import Document
@@ -35,7 +35,7 @@ class PandasExcelReader(BaseReader):
         self._pandas_config = pandas_config
 
     def load_data(
-        self, file: Path, sheet_name: str | int | None = None, extra_info: Optional[Dict] = None
+        self, file: Path, sheet_name: Optional[Union[str, int]] = None, extra_info: Optional[Dict] = None
     ) -> List[Document]:
         """Parse file and extract values from a specific column.
 

--- a/loader_hub/file/pandas_excel/base.py
+++ b/loader_hub/file/pandas_excel/base.py
@@ -35,7 +35,7 @@ class PandasExcelReader(BaseReader):
         self._pandas_config = pandas_config
 
     def load_data(
-        self, file: Path, column_name: str, extra_info: Optional[Dict] = None
+        self, file: Path, extra_info: Optional[Dict] = None
     ) -> List[Document]:
         """Parse file and extract values from a specific column.
 
@@ -45,11 +45,21 @@ class PandasExcelReader(BaseReader):
         Returns:
             List[Document]: A list of`Document objects containing the values from the specified column in the Excel file.
         """
+        import itertools
+
         import pandas as pd
 
-        df = pd.read_excel(file, **self._pandas_config)
+        df = pd.read_excel(file, sheet_name=None, **self._pandas_config)
 
-        text_list = df[column_name].astype(str).tolist()
+        keys = df.keys()
+
+        df_sheets = []
+
+        for key in keys:
+            sheet = df[key].values.astype(str).tolist()
+            df_sheets.append(sheet)
+
+        text_list = list(itertools.chain.from_iterable(df_sheets))  # flatten list of lists
 
         if self._concat_rows:
             return [Document((self._row_joiner).join(text_list), extra_info=extra_info)]


### PR DESCRIPTION
Based on my own use case, I've updated `pandas_excel` loader to maximize batch loading capability. 
* Load entire excel file with multiple sheets
* Option to load individual sheet within excel file
* Load entire sheet without specify `column_name` 

This will greatly improve productivity when loading large quantity of files, and excel with multiple sheets. 