### PR TITLE
Fix the `mbox` module

### DIFF
--- a/loader_hub/file/mbox/base.py
+++ b/loader_hub/file/mbox/base.py
@@ -58,6 +58,9 @@ class MboxReader(BaseReader):
         for _, _msg in enumerate(mbox):
             msg: mailbox.mboxMessage = _msg
             # Parse multipart messages
+
+            content = None
+
             if msg.is_multipart():
                 for part in msg.walk():
                     ctype = part.get_content_type()
@@ -68,6 +71,10 @@ class MboxReader(BaseReader):
             # Get plain message payload for non-multipart messages
             else:
                 content = msg.get_payload(decode=True)
+
+            if not content:
+                print("WARNING loader_hub.file.mbox found messages with content that stayed None. Skipping entry...")
+                continue
 
             # Parse message HTML content and remove unneeded whitespace
             soup = BeautifulSoup(content)


### PR DESCRIPTION
## Overview & Problem
Code I tried to run:
```
MboxReader = download_loader("MboxReader")
documents = MboxReader().load_data(file='./mail.mbox')
```
This failed at specific emails within my inbox (my best bet is that these were entries with empty content) with this error:
```
---------------------------------------------------------------------------
UnboundLocalError                         Traceback (most recent call last)
[/var/folders/61/c5n0s_9x0rz7nyv9b087tjl40000gn/T/ipykernel_62323/3010861897.py](https://file+.vscode-resource.vscode-cdn.net/var/folders/61/c5n0s_9x0rz7nyv9b087tjl40000gn/T/ipykernel_62323/3010861897.py) in 
      4 MboxReader = download_loader("MboxReader")
      5 
----> 6 documents = MboxReader().load_data(file='[./mail.mbox](https://file+.vscode-resource.vscode-cdn.net/Users/raghav/Projects/ted/ted/pipelines/mail.mbox)')

[~/anaconda3/lib/python3.9/site-packages/llama_index/readers/llamahub_modules/file/mbox/base.py](https://file+.vscode-resource.vscode-cdn.net/Users/raghav/Projects/ted/ted/pipelines/~/anaconda3/lib/python3.9/site-packages/llama_index/readers/llamahub_modules/file/mbox/base.py) in load_data(self, file, extra_info)
     99         """
    100         docs: List[Document] = []
--> 101         content = self.parse_file(file)
    102         for msg in content:
    103             docs.append(Document(msg, extra_info=extra_info))

[~/anaconda3/lib/python3.9/site-packages/llama_index/readers/llamahub_modules/file/mbox/base.py](https://file+.vscode-resource.vscode-cdn.net/Users/raghav/Projects/ted/ted/pipelines/~/anaconda3/lib/python3.9/site-packages/llama_index/readers/llamahub_modules/file/mbox/base.py) in parse_file(self, filepath, errors)
     71 
     72             # Parse message HTML content and remove unneeded whitespace
---> 73             soup = BeautifulSoup(content)
     74             stripped_content = " ".join(soup.get_text().split())
     75             # Format message to include date, sender, receiver and subject

UnboundLocalError: local variable 'content' referenced before assignment
```

## Fix
To set `content` to `None` to begin with, and skip emails where we aren't able to find any valid content while printing out a warning so the user knows those entries are being skipped.