### PR TITLE
CouchDB loader bug fix: return documents from loader

### DIFF
--- a/loader_hub/couchdb/base.py
+++ b/loader_hub/couchdb/base.py
@@ -62,7 +62,7 @@ class SimpleCouchDBReader(BaseReader):
                 #check that the id field exists
                 if "id" not in row:
                     raise ValueError("`id` field not found in CouchDB document.")
-                documents.append(Document(json.dumps(row.value)))
+                documents.append(Document(json.dumps(row.doc)))
         else:
             #only one result
             if results.get('docs') is not None:

--- a/loader_hub/couchdb/base.py
+++ b/loader_hub/couchdb/base.py
@@ -72,3 +72,4 @@ class SimpleCouchDBReader(BaseReader):
                         raise ValueError("`_id` field not found in CouchDB document.")
                     documents.append(Document(json.dumps(item)))
 
+        return documents


### PR DESCRIPTION
somehow return statement was lost during version control.  added it back in.