### PR TITLE
Update slackreader to reduce api calls

### DIFF
--- a/loader_hub/slack/README.md
+++ b/loader_hub/slack/README.md
@@ -11,7 +11,7 @@ from llama_index import download_loader
 
 SlackReader = download_loader("SlackReader")
 
-loader = SlackReader()
+loader = SlackReader('<Slack API Token>')
 documents = loader.load_data(channel_ids=['[slack_channel_id1]', '[slack_channel_id2]'])
 ```
 

--- a/loader_hub/slack/base.py
+++ b/loader_hub/slack/base.py
@@ -133,10 +133,13 @@ class SlackReader(BaseReader):
                 logger.info(
                     "{} messages found in {}".format(len(conversation_history), id)
                 )
-                result_messages.extend(
-                    self._read_message(channel_id, message["ts"])
-                    for message in conversation_history
-                )
+                # 'reply_count' is present if there are replies in the 
+                # conversation thread otherwise not.
+                # using it to reduce number of slack api calls.
+                result_messages.extend(self._read_message(channel_id, message["ts"]) 
+                            if 'reply_count' in message 
+                            else message['text'] 
+                            for message in conversation_history)
                 if not result["has_more"]:
                     break
                 next_cursor = result["response_metadata"]["next_cursor"]


### PR DESCRIPTION
Hi,

I added a check for the `reply_count` field in the messages retrieved from the `conversations.history` API call. By doing so, we can determine if a message is a thread and has replies, and use the `conversations.replies` API call to fetch the thread's replies. If a message is not a thread, we can skip the call to `conversations.replies` and reduce the number of API calls, thereby minimizing the risk of hitting the rate limit errors. This change improves the efficiency of the code and helps to prevent potential issues caused by hitting the rate limit.

Thank you.