### PR TITLE
Updated extra_info dictionary and ReadMe file

### DIFF
--- a/loader_hub/file/pymu_pdf/README.md
+++ b/loader_hub/file/pymu_pdf/README.md
@@ -8,12 +8,12 @@ To use this loader, you need to pass file path of the local file as string or `P
 
 ```python
 from pathlib import Path
-from gpt_index import download_loader
+from llama_index import download_loader
 
 PyMuPDFReader = download_loader("PyMuPDFReader")
 
 loader = PyMuPDFReader()
-documents = loader.load(file=Path('./article.pdf'), metadata=True)
+documents = loader.load(file_path=Path('./article.pdf'), metadata=True)
 ```
 
 This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/jerryjliu/gpt_index/tree/main/gpt_index) and/or subsequently used as a Tool in a [LangChain](https://github.com/hwchase17/langchain) Agent. See [here](https://github.com/emptycrown/llama-hub/tree/main) for examples.

--- a/loader_hub/file/pymu_pdf/base.py
+++ b/loader_hub/file/pymu_pdf/base.py
@@ -45,24 +45,19 @@ class PyMuPDFReader(BaseReader):
 
         # if metadata is True, add metadata to each document
         if metadata:
-            metadata_dict = {}
-            metadata_dict["total_pages"] = len(doc)
-            metadata_dict["file_path"] = self.file_path
-
-            # add extra_info to metadata_dict
             if not extra_info:
-                extra_info = metadata_dict
-            else:
-                extra_info = dict(extra_info, **metadata_dict)
+                extra_info = {}
+            extra_info["total_pages"] = len(doc)
+            extra_info["file_path"] = file_path
 
             # return list of documents
             return [
                 Document(
-                    page.get_text().encode("utf-8"),
+                    text=page.get_text().encode("utf-8"),
                     extra_info=dict(
                         extra_info,
                         **{
-                            metadata_dict["source"]: f"{page.number+1}",
+                            "source": f"{page.number+1}",
                         },
                     ),
                 )
@@ -71,6 +66,6 @@ class PyMuPDFReader(BaseReader):
 
         else:
             return [
-                Document(page.get_text().encode("utf-8"), extra_info=extra_info)
+                Document(text=page.get_text().encode("utf-8"), extra_info=extra_info)
                 for page in doc
             ]


### PR DESCRIPTION
As mentioned here https://github.com/emptycrown/llama-hub/issues/239, the ReadMe documentation was incorrect (`TypeError: PyMuPDFReader.load() got an unexpected keyword argument file`). Updated keyword argument from `file` to `file_path` in ReadMe file.
 I have also updated the `extra_info` dictionary. Instead of creating a new dictionary `metadata_dict`, I am storing all basic metadata-related information in `extra_info`.