### PR TITLE
Update the google_drive loader to be able to query files by mimeType

### DIFF
--- a/loader_hub/google_drive/README.md
+++ b/loader_hub/google_drive/README.md
@@ -14,6 +14,10 @@ You can extract a file_id directly from its sharable drive URL.
 
 For example, the file_id of `https://drive.google.com/file/d/1LEqD_zQiOizKrBKZYKJtER_h6i49wE-y/view?usp=sharing` is `1LEqD_zQiOizKrBKZYKJtER_h6i49wE-y`.
 
+### mime_types
+
+You can also filter the files by the mimeType e.g.: `mime_types=["application/vnd.google-apps.document"]`
+
 ## Usage
 
 We need `credentials.json` and `client_secrets.json` files to use this reader.

--- a/loader_hub/google_drive/base.py
+++ b/loader_hub/google_drive/base.py
@@ -106,7 +106,7 @@ class GoogleDriveReader(BaseReader):
         return creds, drive
 
     def _get_fileids_meta(
-        self, folder_id: Optional(str) = None, file_id: Optional(str) = None, mime_types: Optional(list) = None
+        self, folder_id: Optional[str] = None, file_id: Optional[str] = None, mime_types: Optional[list] = None
     ) -> List[str]:
         """Get file ids present in folder/ file id
         Args:


### PR DESCRIPTION
Added the ability to filter files by the mimeType.

Usage example:
loader.load_data(folder_id=folder_id, mime_types=["application/vnd.google-apps.document"])

The script will still search for the files recursively.

LMK if you need me to make any changes.