### PR TITLE
Update after refactoring away parsers in LlamaIndex, also update docs to 0.6.0 API 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ These general-purpose loaders are designed to be used as a way to load data into
 ### LlamaIndex
 
 ```python
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 
 GoogleDocsReader = download_loader('GoogleDocsReader')
 
 gdoc_ids = ['1wf-y2pd9C878Oh-FmLH7Q_BQkljdm6TQal-c1pUfrec']
 loader = GoogleDocsReader()
 documents = loader.load_data(document_ids=gdoc_ids)
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 index.query('Where did the author go to school?')
 ```
 
@@ -29,7 +29,7 @@ index.query('Where did the author go to school?')
 Note: Make sure you change the description of the `Tool` to match your use-case.
 
 ```python
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 from langchain.llms import OpenAI
 from langchain.chains.question_answering import load_qa_chain
 

--- a/loader_hub/azcognitive_search/README.md
+++ b/loader_hub/azcognitive_search/README.md
@@ -29,7 +29,7 @@ documents = reader.load_data(
 
 ```python
 
-    from llama_index import GPTSimpleVectorIndex, download_loader
+    from llama_index import GPTVectorStoreIndex, download_loader
     from langchain.chains.conversation.memory import ConversationBufferMemory
     from langchain.agents import Tool, AgentExecutor, load_tools, initialize_agent
 
@@ -42,7 +42,7 @@ documents = reader.load_data(
 
     documents = az_loader.load_data(query, field_name)
 
-    index = GPTSimpleVectorIndex.from_documents(documents, service_context=service_context)
+    index = GPTVectorStoreIndex.from_documents(documents, service_context=service_context)
 
     tools = [
         Tool(

--- a/loader_hub/file/README.md
+++ b/loader_hub/file/README.md
@@ -22,13 +22,13 @@ This loader is designed to be used as a way to load data into [LlamaIndex](https
 ### LlamaIndex
 
 ```python
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 
 SimpleDirectoryReader = download_loader("SimpleDirectoryReader")
 
 loader = SimpleDirectoryReader('./data', recursive=True, exclude_hidden=True)
 documents = loader.load_data()
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 index.query('What are these files about?')
 ```
 
@@ -37,7 +37,7 @@ index.query('What are these files about?')
 Note: Make sure you change the description of the `Tool` to match your use-case.
 
 ```python
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 from langchain.agents import initialize_agent, Tool
 from langchain.llms import OpenAI
 from langchain.chains.conversation.memory import ConversationBufferMemory
@@ -46,7 +46,7 @@ SimpleDirectoryReader = download_loader("SimpleDirectoryReader")
 
 loader = SimpleDirectoryReader('./data', recursive=True, exclude_hidden=True)
 documents = loader.load_data()
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 
 tools = [
     Tool(

--- a/loader_hub/file/base.py
+++ b/loader_hub/file/base.py
@@ -42,8 +42,8 @@ class SimpleDirectoryReader(BaseReader):
             False by default.
         required_exts (Optional[List[str]]): List of required extensions.
             Default is None.
-        file_extractor (Optional[Dict[str, BaseParser]]): A mapping of file
-            extension to a BaseParser class that specifies how to convert that file
+        file_extractor (Optional[Dict[str, BaseReader]]): A mapping of file
+            extension to a BaseReader class that specifies how to convert that file
             to text. See DEFAULT_FILE_EXTRACTOR.
         num_files_limit (Optional[int]): Maximum number of files to read.
             Default is None.

--- a/loader_hub/file/image/base.py
+++ b/loader_hub/file/image/base.py
@@ -6,7 +6,7 @@ A parser for image files.
 
 import re
 from pathlib import Path
-from typing import Dict, Optional, cast
+from typing import Dict, Optional, cast, List
 
 from llama_index.readers.base import BaseReader
 from llama_index.readers.schema.base import Document, ImageDocument

--- a/loader_hub/file/image/base.py
+++ b/loader_hub/file/image/base.py
@@ -111,7 +111,9 @@ class ImageReader(BaseReader):
                 model = cast(pytesseract, self._parser_config["model"])
                 text_str = model.image_to_string(image)
 
-        return ImageDocument(
-            text=text_str,
-            image=image_str,
-        )
+        return [
+            ImageDocument(
+                text=text_str,
+                image=image_str,
+            )
+        ]

--- a/loader_hub/file/image/base.py
+++ b/loader_hub/file/image/base.py
@@ -9,8 +9,7 @@ from pathlib import Path
 from typing import Dict, Optional, cast
 
 from llama_index.readers.base import BaseReader
-from llama_index.readers.schema.base import Document
-from llama_index.readers.file.base_parser import ImageParserOutput
+from llama_index.readers.schema.base import Document, ImageDocument
 
 
 class ImageReader(BaseReader):
@@ -37,6 +36,7 @@ class ImageReader(BaseReader):
                 model = pytesseract
             else:
                 from transformers import DonutProcessor, VisionEncoderDecoderModel
+
                 processor = DonutProcessor.from_pretrained(
                     "naver-clova-ix/donut-base-finetuned-cord-v2"
                 )
@@ -48,10 +48,9 @@ class ImageReader(BaseReader):
         self._keep_image = keep_image
         self._parse_text = parse_text
 
-
     def load_data(
         self, file: Path, extra_info: Optional[Dict] = None
-    ) -> ImageParserOutput:
+    ) -> List[Document]:
         """Parse file."""
         from PIL import Image
 
@@ -108,10 +107,11 @@ class ImageReader(BaseReader):
                 text_str = re.sub(r"<.*?>", "", sequence, count=1).strip()
             else:
                 import pytesseract
+
                 model = cast(pytesseract, self._parser_config["model"])
                 text_str = model.image_to_string(image)
 
-        return ImageParserOutput(
+        return ImageDocument(
             text=text_str,
             image=image_str,
         )

--- a/loader_hub/github_repo/README.md
+++ b/loader_hub/github_repo/README.md
@@ -54,7 +54,7 @@ export GITHUB_TOKEN='...'
 import pickle
 import os
 
-from llama_index import download_loader, GPTSimpleVectorIndex
+from llama_index import download_loader, GPTVectorStoreIndex
 download_loader("GithubRepositoryReader")
 
 from llama_index.readers.llamahub_modules.github_repo import GithubClient, GithubRepositoryReader
@@ -81,7 +81,7 @@ if docs is None:
     with open("docs.pkl", "wb") as f:
         pickle.dump(docs, f)
 
-index = GPTSimpleVectorIndex.from_documents(docs)
+index = GPTVectorStoreIndex.from_documents(docs)
 
 index.query("Explain each LlamaIndex class?")
 ```

--- a/loader_hub/google_calendar/README.md
+++ b/loader_hub/google_calendar/README.md
@@ -24,12 +24,12 @@ This loader is designed to be used as a way to load data into [LlamaIndex](https
 ### LlamaIndex
 
 ```python
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 
 GoogleCalendarReader = download_loader('GoogleCalendarReader')
 
 loader = GoogleCalendarReader()
 documents = loader.load_data()
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 index.query('When am I meeting Gordon?')
 ```

--- a/loader_hub/google_docs/README.md
+++ b/loader_hub/google_docs/README.md
@@ -25,14 +25,14 @@ This loader is designed to be used as a way to load data into [LlamaIndex](https
 ### LlamaIndex
 
 ```python
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 
 GoogleDocsReader = download_loader('GoogleDocsReader')
 
 gdoc_ids = ['1wf-y2pd9C878Oh-FmLH7Q_BQkljdm6TQal-c1pUfrec']
 loader = GoogleDocsReader()
 documents = loader.load_data(document_ids=gdoc_ids)
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 index.query('Where did the author go to school?')
 ```
 
@@ -41,7 +41,7 @@ index.query('Where did the author go to school?')
 Note: Make sure you change the description of the `Tool` to match your use-case.
 
 ```python
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 from langchain.agents import initialize_agent, Tool
 from langchain.llms import OpenAI
 from langchain.chains.conversation.memory import ConversationBufferMemory
@@ -51,7 +51,7 @@ GoogleDocsReader = download_loader('GoogleDocsReader')
 gdoc_ids = ['1wf-y2pd9C878Oh-FmLH7Q_BQkljdm6TQal-c1pUfrec']
 loader = GoogleDocsReader()
 documents = loader.load_data(document_ids=gdoc_ids)
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 
 tools = [
     Tool(

--- a/loader_hub/google_sheets/README.md
+++ b/loader_hub/google_sheets/README.md
@@ -24,12 +24,12 @@ This loader is designed to be used as a way to load data into [LlamaIndex](https
 ### LlamaIndex
 
 ```python
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 
 GoogleSheetsReader = download_loader('GoogleSheetsReader')
 
 loader = GoogleSheetsReader()
 documents = loader.load_data()
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 index.query('When am I meeting Gordon?')
 ```

--- a/loader_hub/jsondata/README.md
+++ b/loader_hub/jsondata/README.md
@@ -8,7 +8,7 @@ To use this loader, you need to pass in Json data in a Python dictionary.
 
 ```python
 import requests
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 headers = {
     "Authorization": "your_api_token"
 }
@@ -17,7 +17,7 @@ data = requests.get("your-api-url", headers=headers).json()
 JsonDataReader = download_loader("JsonDataReader")
 loader = JsonDataReader()
 documents = loader.load_data(data)
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 index.query("Question about your data")
 ```
 

--- a/loader_hub/make_com/README.md
+++ b/loader_hub/make_com/README.md
@@ -15,7 +15,7 @@ import os
 MakeWrapper = download_loader('MakeWrapper')
 
 # load index from disk
-index = GPTSimpleVectorIndex.load_from_disk('../vector_indices/index_simple.json')
+index = GPTVectorStoreIndex.load_from_disk('../vector_indices/index_simple.json')
 
 # query index
 query_str = "What did the author do growing up?"

--- a/loader_hub/obsidian/base.py
+++ b/loader_hub/obsidian/base.py
@@ -11,7 +11,7 @@ from typing import Any, List
 
 from langchain.docstore.document import Document as LCDocument
 from llama_index.readers.base import BaseReader
-from llama_index.readers.file.markdown_parser import MarkdownParser
+from llama_index.readers.file.markdown_reader import MarkdownReader
 from llama_index.readers.schema.base import Document
 
 
@@ -29,15 +29,15 @@ class ObsidianReader(BaseReader):
 
     def load_data(self, *args: Any, **load_kwargs: Any) -> List[Document]:
         """Load data from the input directory."""
-        docs: List[str] = []
+        docs: List[Document] = []
         for (dirpath, dirnames, filenames) in os.walk(self.input_dir):
             dirnames[:] = [d for d in dirnames if not d.startswith(".")]
             for filename in filenames:
                 if filename.endswith(".md"):
                     filepath = os.path.join(dirpath, filename)
-                    content = MarkdownParser().parse_file(Path(filepath))
+                    content = MarkdownReader().load_data(Path(filepath))
                     docs.extend(content)
-        return [Document(d) for d in docs]
+        return docs
 
     def load_langchain_documents(self, **load_kwargs: Any) -> List[LCDocument]:
         """Load data in LangChain document format."""

--- a/loader_hub/opendal_reader/azblob/base.py
+++ b/loader_hub/opendal_reader/azblob/base.py
@@ -34,8 +34,8 @@ class OpendalAzblobReader(BaseReader):
         endpoint Optional[str]: the endpoint of the azblob service.
         account_name (Optional[str]): provide azblob access key directly.
         account_key (Optional[str]): provide azblob access key directly.
-        file_extractor (Optional[Dict[str, BaseParser]]): A mapping of file
-            extension to a BaseParser class that specifies how to convert that file
+        file_extractor (Optional[Dict[str, BaseReader]]): A mapping of file
+            extension to a BaseReader class that specifies how to convert that file
             to text. See `SimpleDirectoryReader` for more details.
 
         """

--- a/loader_hub/opendal_reader/base.py
+++ b/loader_hub/opendal_reader/base.py
@@ -30,8 +30,8 @@ class OpendalReader(BaseReader):
         scheme (str): the scheme of the service
         path (str): the path of the data. If none is provided,
             this loader will iterate through the entire bucket. If path is endswith `/`, this loader will iterate through the entire dir. Otherwise, this loeader will load the file.
-        file_extractor (Optional[Dict[str, BaseParser]]): A mapping of file
-            extension to a BaseParser class that specifies how to convert that file
+        file_extractor (Optional[Dict[str, BaseReader]]): A mapping of file
+            extension to a BaseReader class that specifies how to convert that file
             to text. See `SimpleDirectoryReader` for more details.
         """
         import opendal

--- a/loader_hub/opendal_reader/gcs/base.py
+++ b/loader_hub/opendal_reader/gcs/base.py
@@ -32,8 +32,8 @@ class OpendalGcsReader(BaseReader):
             this loader will iterate through the entire bucket. If path is endswith `/`, this loader will iterate through the entire dir. Otherwise, this loeader will load the file.
         endpoint Optional[str]: the endpoint of the azblob service.
         credentials (Optional[str]): provide credential string for GCS OAuth2 directly.
-        file_extractor (Optional[Dict[str, BaseParser]]): A mapping of file
-            extension to a BaseParser class that specifies how to convert that file
+        file_extractor (Optional[Dict[str, BaseReader]]): A mapping of file
+            extension to a BaseReader class that specifies how to convert that file
             to text. See `SimpleDirectoryReader` for more details.
 
         """

--- a/loader_hub/opendal_reader/s3/base.py
+++ b/loader_hub/opendal_reader/s3/base.py
@@ -36,8 +36,8 @@ class OpendalS3Reader(BaseReader):
         region: Optional[str]: the region of the S3 service.
         access_key_id (Optional[str]): provide AWS access key directly.
         secret_access_key (Optional[str]): provide AWS access key directly.
-        file_extractor (Optional[Dict[str, BaseParser]]): A mapping of file
-            extension to a BaseParser class that specifies how to convert that file
+        file_extractor (Optional[Dict[str, BaseReader]]): A mapping of file
+            extension to a BaseReader class that specifies how to convert that file
             to text. See `SimpleDirectoryReader` for more details.
         """
         super().__init__()

--- a/loader_hub/outlook_localcalendar/README.md
+++ b/loader_hub/outlook_localcalendar/README.md
@@ -26,14 +26,14 @@ This loader is designed to be used as a way to load data into [LlamaIndex](https
 ### LlamaIndex
 
 ```python
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 
 OutlookCalendarReader = download_loader('OutlookLocalCalendarReader')
 
 loader = OutlookCalendarReader(start_date='2022-01-01',number_of_documents=1000)
 
 documents = loader.load_data()
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 index.query('When did I last see George Guava? When do I see him again?')
 ```
 Note: it is actually better to give s structured prompt with this data and be sure to it is clear what today's date is and whether you want any data besides the indexed data used in answering the prompt.

--- a/loader_hub/readwise/README.md
+++ b/loader_hub/readwise/README.md
@@ -12,13 +12,13 @@ Here is an example usage of the Readwise Reader:
 
 ```python
 import os
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 
 ReadwiseReader = download_loader("ReadwiseReader")
 token = os.getenv("READWISE_API_KEY")
 loader = ReadwiseReader(api_key=token)
 documents = loader.load_data()
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 
 index.query("What was the paper 'Attention is all you need' about?")
 ```
@@ -28,14 +28,14 @@ You can also query for highlights that have been created after a certain time:
 ```python
 import os
 import datetime
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 
 ReadwiseReader = download_loader("ReadwiseReader")
 token = os.getenv("READWISE_API_KEY")
 loader = ReadwiseReader(api_key=token)
 seven_days_ago = datetime.datetime.now() - datetime.timedelta(days=7)
 documents = loader.load_data(updated_after=seven_days_ago)
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 
 index.query("What has Elon Musk done this time?")
 ```

--- a/loader_hub/reddit/README.md
+++ b/loader_hub/reddit/README.md
@@ -15,7 +15,7 @@ For any subreddit(s) you're interested in, search for relevant posts using keywo
 ### LlamaIndex
 
 ```python
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 
 RedditReader = download_loader('RedditReader')
 
@@ -25,7 +25,7 @@ post_limit = 10
 
 loader = RedditReader()
 documents = loader.load_data(subreddits=subreddits, search_keys=search_keys, post_limit=post_limit)
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 
 index.query("What are the pain points of PyTorch users?")
 ```
@@ -33,7 +33,7 @@ index.query("What are the pain points of PyTorch users?")
 ### LangChain
 
 ```python
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 
 from langchain.agents import initialize_agent, Tool
 from langchain.llms import OpenAI
@@ -47,7 +47,7 @@ post_limit = 10
 
 loader = RedditReader()
 documents = loader.load_data(subreddits=subreddits, search_keys=search_keys, post_limit=post_limit)
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 
 tools = [
     Tool(

--- a/loader_hub/s3/base.py
+++ b/loader_hub/s3/base.py
@@ -38,8 +38,8 @@ class S3Reader(BaseReader):
             this loader will iterate through the entire bucket.
         prefix (Optional[str]): the prefix to filter by in the case that the loader
             iterates through the entire bucket. Defaults to empty string.
-        file_extractor (Optional[Dict[str, BaseParser]]): A mapping of file
-            extension to a BaseParser class that specifies how to convert that file
+        file_extractor (Optional[Dict[str, BaseReader]]): A mapping of file
+            extension to a BaseReader class that specifies how to convert that file
             to text. See `SimpleDirectoryReader` for more details.
         aws_access_id (Optional[str]): provide AWS access key directly.
         aws_access_secret (Optional[str]): provide AWS access key directly.

--- a/loader_hub/spotify/README.md
+++ b/loader_hub/spotify/README.md
@@ -29,12 +29,12 @@ This loader is designed to be used as a way to load data into [LlamaIndex](https
 ### LlamaIndex
 
 ```python
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 
 SpotifyReader = download_loader('SpotifyReader')
 
 loader = SpotifyReader()
 documents = loader.load_data()
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 index.query('When are some other artists i might like based on what i listen to ?')
 ```

--- a/loader_hub/web/beautiful_soup_web/README.md
+++ b/loader_hub/web/beautiful_soup_web/README.md
@@ -36,13 +36,13 @@ This loader is designed to be used as a way to load data into [LlamaIndex](https
 ### LlamaIndex
 
 ```python
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 
 BeautifulSoupWebReader = download_loader("BeautifulSoupWebReader")
 
 loader = BeautifulSoupWebReader()
 documents = loader.load_data(urls=['https://google.com'])
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 index.query('What language is on this website?')
 ```
 
@@ -51,7 +51,7 @@ index.query('What language is on this website?')
 Note: Make sure you change the description of the `Tool` to match your use-case.
 
 ```python
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 from langchain.agents import initialize_agent, Tool
 from langchain.llms import OpenAI
 from langchain.chains.conversation.memory import ConversationBufferMemory
@@ -60,7 +60,7 @@ BeautifulSoupWebReader = download_loader("BeautifulSoupWebReader")
 
 loader = BeautifulSoupWebReader()
 documents = loader.load_data(urls=['https://google.com'])
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 
 tools = [
     Tool(

--- a/loader_hub/web/knowledge_base/README.md
+++ b/loader_hub/web/knowledge_base/README.md
@@ -37,7 +37,7 @@ This loader is designed to be used as a way to load data into [LlamaIndex](https
 ### LlamaIndex
 
 ```python
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 
 KnowledgeBaseWebReader = download_loader("KnowledgeBaseWebReader")
 
@@ -50,7 +50,7 @@ documents = loader.load_data(
   title_selector='.article-title'
   subtitle_selector='.article-subtitle'
   )
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 index.query('What languages does Intercom support?')
 ```
 
@@ -59,7 +59,7 @@ index.query('What languages does Intercom support?')
 Note: Make sure you change the description of the `Tool` to match your use-case.
 
 ```python
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 from langchain.agents import initialize_agent, Tool
 from langchain.llms import OpenAI
 from langchain.chains.conversation.memory import ConversationBufferMemory
@@ -75,7 +75,7 @@ documents = loader.load_data(
   title_selector='.article-title'
   subtitle_selector='.article-subtitle'
   )
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 
 tools = [
     Tool(

--- a/loader_hub/web/readability_web/README.md
+++ b/loader_hub/web/readability_web/README.md
@@ -38,7 +38,7 @@ ReadabilityWebPageReader = download_loader("ReadabilityWebPageReader")
 loader = ReadabilityWebPageReader()
 documents = loader.load_data(url='https://support.squarespace.com/hc/en-us/articles/206795137-Pages-and-content-basics')
 
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 print(index.query('What is pages?'))
 
 ```
@@ -48,7 +48,7 @@ print(index.query('What is pages?'))
 Note: Make sure you change the description of the `Tool` to match your use-case.
 
 ```python
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 from langchain.agents import initialize_agent, Tool
 from langchain.llms import OpenAI
 from langchain.chains.conversation.memory import ConversationBufferMemory
@@ -58,7 +58,7 @@ ReadabilityWebPageReader = download_loader("ReadabilityWebPageReader")
 loader = ReadabilityWebPageReader()
 documents = loader.load_data(url='https://support.squarespace.com/hc/en-us/articles/206795137-Pages-and-content-basics')
 
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 
 tools = [
     Tool(

--- a/loader_hub/web/simple_web/README.md
+++ b/loader_hub/web/simple_web/README.md
@@ -22,13 +22,13 @@ This loader is designed to be used as a way to load data into [LlamaIndex](https
 ### LlamaIndex
 
 ```python
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 
 SimpleWebPageReader = download_loader("SimpleWebPageReader")
 
 loader = SimpleWebPageReader()
 documents = loader.load_data(urls=['https://google.com'])
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 index.query('What language is on this website?')
 ```
 
@@ -37,7 +37,7 @@ index.query('What language is on this website?')
 Note: Make sure you change the description of the `Tool` to match your use-case.
 
 ```python
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 from langchain.agents import initialize_agent, Tool
 from langchain.llms import OpenAI
 from langchain.chains.conversation.memory import ConversationBufferMemory
@@ -46,7 +46,7 @@ SimpleWebPageReader = download_loader("SimpleWebPageReader")
 
 loader = SimpleWebPageReader()
 documents = loader.load_data(urls=['https://google.com'])
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 
 tools = [
     Tool(

--- a/loader_hub/web/trafilatura_web/README.md
+++ b/loader_hub/web/trafilatura_web/README.md
@@ -22,13 +22,13 @@ This loader is designed to be used as a way to load data into [LlamaIndex](https
 ### LlamaIndex
 
 ```python
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 
 TrafilaturaWebReader = download_loader("TrafilaturaWebReader")
 
 loader = TrafilaturaWebReader()
 documents = loader.load_data(urls=['https://google.com'])
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 index.query('What language is on this website?')
 ```
 
@@ -37,7 +37,7 @@ index.query('What language is on this website?')
 Note: Make sure you change the description of the `Tool` to match your use-case.
 
 ```python
-from llama_index import GPTSimpleVectorIndex, download_loader
+from llama_index import GPTVectorStoreIndex, download_loader
 from langchain.agents import initialize_agent, Tool
 from langchain.llms import OpenAI
 from langchain.chains.conversation.memory import ConversationBufferMemory
@@ -46,7 +46,7 @@ TrafilaturaWebReader = download_loader("TrafilaturaWebReader")
 
 loader = TrafilaturaWebReader()
 documents = loader.load_data(urls=['https://google.com'])
-index = GPTSimpleVectorIndex(documents)
+index = GPTVectorStoreIndex.from_documents(documents)
 
 tools = [
     Tool(

--- a/tests/tests_confluence/test_confluence_reader.py
+++ b/tests/tests_confluence/test_confluence_reader.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import patch
 from loader_hub.confluence.base import ConfluenceReader, Document
 
+
 @pytest.fixture
 def mock_confluence():
     with patch("atlassian.Confluence") as mock_confluence:
@@ -18,45 +19,69 @@ MOCK_OAUTH = {
     },
 }
 
-class TestConfluenceReader:
 
+class TestConfluenceReader:
     def test_confluence_reader_initialization(self, mock_confluence):
 
         # Test with oauth2
         ConfluenceReader(base_url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH)
-        mock_confluence.assert_called_once_with(url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH, cloud=True)
+        mock_confluence.assert_called_once_with(
+            url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH, cloud=True
+        )
 
         # Test without oauth2
-        with unittest.mock.patch.dict("os.environ", {"CONFLUENCE_USERNAME": "user", "CONFLUENCE_API_TOKEN": "api_token"}):
+        with unittest.mock.patch.dict(
+            "os.environ",
+            {"CONFLUENCE_USERNAME": "user", "CONFLUENCE_API_TOKEN": "api_token"},
+        ):
             ConfluenceReader(base_url=CONFLUENCE_BASE_URL)
-            mock_confluence.assert_called_with(url=CONFLUENCE_BASE_URL, username="user", password="api_token", cloud=True)
+            mock_confluence.assert_called_with(
+                url=CONFLUENCE_BASE_URL,
+                username="user",
+                password="api_token",
+                cloud=True,
+            )
 
     def test_confluence_reader_load_data_invalid_args(self, mock_confluence):
-        confluence_reader = ConfluenceReader(base_url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH)
+        confluence_reader = ConfluenceReader(
+            base_url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH
+        )
         confluence_reader.confluence = mock_confluence
 
-        with pytest.raises(ValueError, match="Must specify at least one among `space_key`, `page_ids`, `label`, `cql` parameters."):
+        with pytest.raises(
+            ValueError,
+            match="Must specify at least one among `space_key`, `page_ids`, `label`, `cql` parameters.",
+        ):
             confluence_reader.load_data()
-
 
     def test_confluence_reader_load_data_by_page_ids(self, mock_confluence):
         mock_confluence.get_page_by_id.side_effect = [
-            {'id': '123', 'title': 'Page 123', 'body': {'storage': {'value': '<p>Content 123</p>'}}},
-            {'id': '456', 'title': 'Page 456', 'body': {'storage': {'value': '<p>Content 456</p>'}}}
+            {
+                "id": "123",
+                "title": "Page 123",
+                "body": {"storage": {"value": "<p>Content 123</p>"}},
+            },
+            {
+                "id": "456",
+                "title": "Page 456",
+                "body": {"storage": {"value": "<p>Content 456</p>"}},
+            },
         ]
 
-        confluence_reader = ConfluenceReader(base_url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH)
+        confluence_reader = ConfluenceReader(
+            base_url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH
+        )
         confluence_reader.confluence = mock_confluence
 
-        mock_page_ids = ['123', '456']
+        mock_page_ids = ["123", "456"]
         documents = confluence_reader.load_data(page_ids=mock_page_ids)
 
         assert len(documents) == 2
         assert all(isinstance(doc, Document) for doc in documents)
         assert documents[0].doc_id == "123"
-        assert documents[0].extra_info == { "title": "Page 123" }
+        assert documents[0].extra_info == {"title": "Page 123"}
         assert documents[1].doc_id == "456"
-        assert documents[1].extra_info == { "title": "Page 456" }
+        assert documents[1].extra_info == {"title": "Page 456"}
 
         assert mock_confluence.get_page_by_id.call_count == 2
 
@@ -69,38 +94,40 @@ class TestConfluenceReader:
         # one response with two pages
         mock_confluence.get_all_pages_from_space.return_value = [
             {
-                'id': '123',
-                'type': 'page',
-                'status': 'current',
-                'title': 'Page 123',
-                'body': {'storage': {'value': '<p>Content 123</p>'}}
+                "id": "123",
+                "type": "page",
+                "status": "current",
+                "title": "Page 123",
+                "body": {"storage": {"value": "<p>Content 123</p>"}},
             },
             {
-                'id': '456',
-                'type': 'page',
-                'status': 'current',
-                'title': 'Page 456',
-                'body': {'storage': {'value': '<p>Content 456</p>'}}
-            }
+                "id": "456",
+                "type": "page",
+                "status": "current",
+                "title": "Page 456",
+                "body": {"storage": {"value": "<p>Content 456</p>"}},
+            },
         ]
 
-        confluence_reader = ConfluenceReader(base_url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH)
+        confluence_reader = ConfluenceReader(
+            base_url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH
+        )
         confluence_reader.confluence = mock_confluence
 
-        mock_space_key = 'spaceId123'
+        mock_space_key = "spaceId123"
         documents = confluence_reader.load_data(space_key=mock_space_key)
 
         assert mock_confluence.get_all_pages_from_space.call_count == 1
-        assert mock_confluence.get_all_pages_from_space.call_args[0][0] == 'spaceId123'
-        assert mock_confluence.get_all_pages_from_space.call_args[1]['start'] == 0
-        assert mock_confluence.get_all_pages_from_space.call_args[1]['limit'] == 50
+        assert mock_confluence.get_all_pages_from_space.call_args[0][0] == "spaceId123"
+        assert mock_confluence.get_all_pages_from_space.call_args[1]["start"] == 0
+        assert mock_confluence.get_all_pages_from_space.call_args[1]["limit"] == 50
 
         assert len(documents) == 2
         assert all(isinstance(doc, Document) for doc in documents)
         assert documents[0].doc_id == "123"
-        assert documents[0].extra_info == { "title": "Page 123" }
+        assert documents[0].extra_info == {"title": "Page 123"}
         assert documents[1].doc_id == "456"
-        assert documents[1].extra_info == { "title": "Page 456" }
+        assert documents[1].extra_info == {"title": "Page 456"}
 
         assert mock_confluence.get_page_by_id.call_count == 0
         assert mock_confluence.get_all_pages_by_label.call_count == 0
@@ -112,40 +139,44 @@ class TestConfluenceReader:
         mock_confluence.get_all_pages_from_space.side_effect = [
             [
                 {
-                'id': '123',
-                'type': 'page',
-                'status': 'current',
-                'title': 'Page 123',
-                'body': {'storage': {'value': '<p>Content 123</p>'}}
+                    "id": "123",
+                    "type": "page",
+                    "status": "current",
+                    "title": "Page 123",
+                    "body": {"storage": {"value": "<p>Content 123</p>"}},
                 },
             ],
             [
                 {
-                'id': '456',
-                'type': 'page',
-                'status': 'current',
-                'title': 'Page 456',
-                'body': {'storage': {'value': '<p>Content 456</p>'}}
+                    "id": "456",
+                    "type": "page",
+                    "status": "current",
+                    "title": "Page 456",
+                    "body": {"storage": {"value": "<p>Content 456</p>"}},
                 }
             ],
-            []
+            [],
         ]
 
-        confluence_reader = ConfluenceReader(base_url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH)
+        confluence_reader = ConfluenceReader(
+            base_url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH
+        )
         confluence_reader.confluence = mock_confluence
 
-        mock_space_key = 'spaceId123'
-        mock_limit = 1 # fetch one page at a time
-        documents = confluence_reader.load_data(space_key=mock_space_key, limit=mock_limit)
+        mock_space_key = "spaceId123"
+        mock_limit = 1  # fetch one page at a time
+        documents = confluence_reader.load_data(
+            space_key=mock_space_key, limit=mock_limit
+        )
 
         assert mock_confluence.get_all_pages_from_space.call_count == 3
 
         assert len(documents) == 2
         assert all(isinstance(doc, Document) for doc in documents)
         assert documents[0].doc_id == "123"
-        assert documents[0].extra_info == { "title": "Page 123" }
+        assert documents[0].extra_info == {"title": "Page 123"}
         assert documents[1].doc_id == "456"
-        assert documents[1].extra_info == { "title": "Page 456" }
+        assert documents[1].extra_info == {"title": "Page 456"}
 
         assert mock_confluence.get_page_by_id.call_count == 0
         assert mock_confluence.get_all_pages_by_label.call_count == 0


### PR DESCRIPTION
### Summary
* Remove use of `*Parser` and `ImageParserOutput` after it's been removed from LlamaIndex
* Also update docs from `GPTSimpleVectorIndex(...)` to `GPTVectorStoreIndex.from_documents(...)` 