### PR TITLE
File reference metadata

### DIFF
--- a/loader_hub/file/docx/base.py
+++ b/loader_hub/file/docx/base.py
@@ -17,5 +17,9 @@ class DocxReader(BaseReader):
         import docx2txt
 
         text = docx2txt.process(file)
+        metadata = {"file_name": file.name}
+
+        if extra_info is not None:
+            metadata.update(extra_info)
 
         return [Document(text, extra_info=extra_info)]

--- a/loader_hub/file/docx/base.py
+++ b/loader_hub/file/docx/base.py
@@ -22,4 +22,4 @@ class DocxReader(BaseReader):
         if extra_info is not None:
             metadata.update(extra_info)
 
-        return [Document(text, extra_info=extra_info)]
+        return [Document(text, extra_info=metadata)]

--- a/loader_hub/file/pdf/base.py
+++ b/loader_hub/file/pdf/base.py
@@ -14,12 +14,12 @@ class PDFReader(BaseReader):
         self, file: Path, extra_info: Optional[Dict] = None
     ) -> List[Document]:
         """Parse file."""
-        import PyPDF2
+        import pypdf
 
         text_list = []
         with open(file, "rb") as fp:
             # Create a PDF object
-            pdf = PyPDF2.PdfReader(fp)
+            pdf = pypdf.PdfReader(fp)
 
             # Get the number of pages in the PDF document
             num_pages = len(pdf.pages)
@@ -29,6 +29,11 @@ class PDFReader(BaseReader):
                 # Extract the text from the page
                 page_text = pdf.pages[page].extract_text()
                 text_list.append(page_text)
+                page_label = pdf.page_labels[page]
+                metadata = {"page_label": page_label, "file_name":file.name}
+                if extra_info is not None:
+                    metadata.update(extra_info)
+                
         text = "\n".join(text_list)
 
         return [Document(text, extra_info=extra_info)]

--- a/loader_hub/file/pdf/base.py
+++ b/loader_hub/file/pdf/base.py
@@ -25,15 +25,16 @@ class PDFReader(BaseReader):
             num_pages = len(pdf.pages)
 
             # Iterate over every page
+            docs = []
             for page in range(num_pages):
                 # Extract the text from the page
                 page_text = pdf.pages[page].extract_text()
                 text_list.append(page_text)
                 page_label = pdf.page_labels[page]
                 metadata = {"page_label": page_label, "file_name":file.name}
+                
                 if extra_info is not None:
                     metadata.update(extra_info)
-                
-        text = "\n".join(text_list)
-
-        return [Document(text, extra_info=metadata)]
+                    
+                docs.append(Document(page_text, extra_info=metadata))
+        return docs

--- a/loader_hub/file/pdf/base.py
+++ b/loader_hub/file/pdf/base.py
@@ -36,4 +36,4 @@ class PDFReader(BaseReader):
                 
         text = "\n".join(text_list)
 
-        return [Document(text, extra_info=extra_info)]
+        return [Document(text, extra_info=metadata)]

--- a/loader_hub/file/pdf/base.py
+++ b/loader_hub/file/pdf/base.py
@@ -16,7 +16,6 @@ class PDFReader(BaseReader):
         """Parse file."""
         import pypdf
 
-        text_list = []
         with open(file, "rb") as fp:
             # Create a PDF object
             pdf = pypdf.PdfReader(fp)
@@ -29,7 +28,6 @@ class PDFReader(BaseReader):
             for page in range(num_pages):
                 # Extract the text from the page
                 page_text = pdf.pages[page].extract_text()
-                text_list.append(page_text)
                 page_label = pdf.page_labels[page]
                 metadata = {"page_label": page_label, "file_name":file.name}
                 
@@ -37,4 +35,4 @@ class PDFReader(BaseReader):
                     metadata.update(extra_info)
                     
                 docs.append(Document(page_text, extra_info=metadata))
-        return docs
+            return docs

--- a/loader_hub/file/pdf/requirements.txt
+++ b/loader_hub/file/pdf/requirements.txt
@@ -1,1 +1,1 @@
-PyPDF2
+pypdf


### PR DESCRIPTION
### Summary
- Replaced `PyPDF2` with `pypdf` library to get page reference.
- Added support for including page reference for pdf file. Added by [Simon](https://github.com/Disiok) on llama-Index.
- Added support for adding file name in metadata for PDF and Docx type document

### Reason to make these changes
This will help in case when the person is handling multiple documents at once. Not only we can provide the response but also the page reference in case of pdf file and also the file name in case of pdf and docx document. This makes it easier to find the exact document.