### PR TITLE
Added JoplinReader

### DIFF
--- a/loader_hub/joplin/README.md
+++ b/loader_hub/joplin/README.md
@@ -1,0 +1,28 @@
+# Joplin (Markdown) Loader
+
+>[Joplin](https://joplinapp.org/) is an open source note-taking app. Capture your thoughts and securely access them from any device.
+
+This readme covers how to load documents from a `Joplin` database.
+
+`Joplin` has a [REST API](https://joplinapp.org/api/references/rest_api/) for accessing its local database. This reader uses the API to retrieve all notes in the database and their metadata. This requires an access token that can be obtained from the app by following these steps:
+
+1. Open the `Joplin` app. The app must stay open while the documents are being loaded.
+2. Go to settings / options and select "Web Clipper".
+3. Make sure that the Web Clipper service is enabled.
+4. Under "Advanced Options", copy the authorization token.
+
+You may either initialize the reader directly with the access token, or store it in the environment variable JOPLIN_ACCESS_TOKEN.
+
+An alternative to this approach is to export the `Joplin`'s note database to Markdown files (optionally, with Front Matter metadata) and use a Markdown reader, such as ObsidianReader, to load them.
+
+## Usage
+
+Here's an example usage of the JoplinReader.
+
+```python
+from llama_index import download_loader
+import os
+
+JoplinReader = download_loader('JoplinReader')
+documents = JoplinReader(access_token='<access_token>').load_data()  # Returns list of documents
+```

--- a/loader_hub/joplin/base.py
+++ b/loader_hub/joplin/base.py
@@ -10,7 +10,6 @@ import os
 from typing import Any, Iterator, List, Optional
 import urllib
 
-from langchain.docstore.document import Document as LCDocument
 from llama_index.readers.base import BaseReader
 from llama_index.readers.schema.base import Document
 

--- a/loader_hub/joplin/base.py
+++ b/loader_hub/joplin/base.py
@@ -25,7 +25,8 @@ class JoplinReader(BaseReader):
     Web Clipper enabled (look for "Web Clipper" in the app settings).
 
     To get the access token, you need to go to the Web Clipper options and
-    under "Advanced Options" you will find the access token.
+    under "Advanced Options" you will find the access token. You may provide
+    it as an argument or set the JOPLIN_ACCESS_TOKEN environment variable.
 
     You can find more information about the Web Clipper service here:
     https://joplinapp.org/clipper/
@@ -36,6 +37,15 @@ class JoplinReader(BaseReader):
         port: int = 41184,
         host: str = "localhost",
     ) -> None:
+        """
+        Initialize a new instance of JoplinReader.
+
+        Args:
+            access_token (Optional[str]): The access token for Joplin's Web Clipper service.
+                If not provided, the JOPLIN_ACCESS_TOKEN environment variable is used. Default is None.
+            port (int): The port on which Joplin's Web Clipper service is running. Default is 41184.
+            host (str): The host on which Joplin's Web Clipper service is running. Default is "localhost".
+        """
         access_token = access_token or self._get_token_from_env()
         base_url = f"http://{host}:{port}"
         self._get_note_url = (

--- a/loader_hub/joplin/base.py
+++ b/loader_hub/joplin/base.py
@@ -73,7 +73,7 @@ class JoplinReader(BaseReader):
                         "created_time": self._convert_date(note["created_time"]),
                         "updated_time": self._convert_date(note["updated_time"]),
                     }
-                    yield Document(text=note["body"], doc_id=note["id"], extra_info=metadata)
+                    yield Document(text=note["body"], extra_info=metadata)
 
                 has_more = json_data["has_more"]
                 page += 1

--- a/loader_hub/joplin/base.py
+++ b/loader_hub/joplin/base.py
@@ -98,8 +98,3 @@ class JoplinReader(BaseReader):
 
     def load_data(self) -> List[Document]:
         return list(self.lazy_load())
-
-    def load_langchain_documents(self, **load_kwargs: Any) -> List[LCDocument]:
-        """Load data in LangChain document format."""
-        docs = self.load_data(**load_kwargs)
-        return [d.to_langchain_format() for d in docs]

--- a/loader_hub/joplin/base.py
+++ b/loader_hub/joplin/base.py
@@ -1,0 +1,105 @@
+"""Joplin reader class.
+
+When Joplin is installed and running it will parse all markdown
+files into a List of Documents.
+
+"""
+from datetime import datetime
+import json
+import os
+from typing import Any, Iterator, List, Optional
+import urllib
+
+from langchain.docstore.document import Document as LCDocument
+from llama_index.readers.base import BaseReader
+from llama_index.readers.schema.base import Document
+
+LINK_NOTE_TEMPLATE = "joplin://x-callback-url/openNote?id={id}"
+
+
+class JoplinReader(BaseReader):
+    """
+    Reader that fetches notes from Joplin.
+
+    In order to use this reader, you need to have Joplin running with the
+    Web Clipper enabled (look for "Web Clipper" in the app settings).
+
+    To get the access token, you need to go to the Web Clipper options and
+    under "Advanced Options" you will find the access token.
+
+    You can find more information about the Web Clipper service here:
+    https://joplinapp.org/clipper/
+    """
+    def __init__(
+        self,
+        access_token: Optional[str] = None,
+        port: int = 41184,
+        host: str = "localhost",
+    ) -> None:
+        access_token = access_token or self._get_token_from_env()
+        base_url = f"http://{host}:{port}"
+        self._get_note_url = (
+            f"{base_url}/notes?token={access_token}"
+            f"&fields=id,parent_id,title,body,created_time,updated_time&page={{page}}"
+        )
+        self._get_folder_url = (
+            f"{base_url}/folders/{{id}}?token={access_token}&fields=title"
+        )
+        self._get_tag_url = (
+            f"{base_url}/notes/{{id}}/tags?token={access_token}&fields=title"
+        )
+
+    def _get_token_from_env(self) -> str:
+        if "JOPLIN_ACCESS_TOKEN" in os.environ:
+            return os.environ["JOPLIN_ACCESS_TOKEN"]
+        else:
+            raise ValueError(
+                "You need to provide an access token to use the Joplin reader. You may provide it as an argument or set the JOPLIN_ACCESS_TOKEN environment variable."
+            )
+
+    def _get_notes(self) -> Iterator[Document]:
+        has_more = True
+        page = 1
+        while has_more:
+            req_note = urllib.request.Request(self._get_note_url.format(page=page))
+            with urllib.request.urlopen(req_note) as response:
+                json_data = json.loads(response.read().decode())
+                for note in json_data["items"]:
+                    metadata = {
+                        "source": LINK_NOTE_TEMPLATE.format(id=note["id"]),
+                        "folder": self._get_folder(note["parent_id"]),
+                        "tags": self._get_tags(note["id"]),
+                        "title": note["title"],
+                        "created_time": self._convert_date(note["created_time"]),
+                        "updated_time": self._convert_date(note["updated_time"]),
+                    }
+                    yield Document(text=note["body"], doc_id=note["id"], extra_info=metadata)
+
+                has_more = json_data["has_more"]
+                page += 1
+
+    def _get_folder(self, folder_id: str) -> str:
+        req_folder = urllib.request.Request(self._get_folder_url.format(id=folder_id))
+        with urllib.request.urlopen(req_folder) as response:
+            json_data = json.loads(response.read().decode())
+            return json_data["title"]
+
+    def _get_tags(self, note_id: str) -> List[str]:
+        req_tag = urllib.request.Request(self._get_tag_url.format(id=note_id))
+        with urllib.request.urlopen(req_tag) as response:
+            json_data = json.loads(response.read().decode())
+            return ','.join([tag["title"] for tag in json_data["items"]])
+
+    def _convert_date(self, date: int) -> str:
+        return datetime.fromtimestamp(date / 1000).strftime("%Y-%m-%d %H:%M:%S")
+
+    def lazy_load(self) -> Iterator[Document]:
+        yield from self._get_notes()
+
+    def load_data(self) -> List[Document]:
+        return list(self.lazy_load())
+
+    def load_langchain_documents(self, **load_kwargs: Any) -> List[LCDocument]:
+        """Load data in LangChain document format."""
+        docs = self.load_data(**load_kwargs)
+        return [d.to_langchain_format() for d in docs]

--- a/loader_hub/library.json
+++ b/loader_hub/library.json
@@ -141,6 +141,10 @@
     "id": "notion",
     "author": "jerryjliu"
   },
+  "JoplinReader": {
+    "id": "joplin",
+    "author": "alondmnt"
+  },
   "ObsidianReader": {
     "id": "obsidian",
     "author": "hursh-desai"


### PR DESCRIPTION
[Joplin](https://joplinapp.org/) is an open source note-taking app.

Joplin has a [REST API](https://joplinapp.org/api/references/rest_api/) for accessing its local database. The proposed `JoplinReader` uses the API to retrieve all notes in the database and their metadata. Joplin needs to be installed and running locally, and an access token is required.