### PR TITLE
Update github_repo with llama_hub package

### DIFF
--- a/llama_hub/github_repo/README.md
+++ b/llama_hub/github_repo/README.md
@@ -18,7 +18,7 @@ import os
 from llama_index import download_loader
 download_loader("GithubRepositoryReader")
 
-from llama_index.readers.llamahub_modules.github_repo import GithubRepositoryReader, GithubClient
+from llama_hub.github_repo import GithubRepositoryReader, GithubClient
 
 github_client = GithubClient(os.getenv("GITHUB_TOKEN"))
 loader = GithubRepositoryReader(
@@ -57,7 +57,7 @@ import os
 from llama_index import download_loader, GPTVectorStoreIndex
 download_loader("GithubRepositoryReader")
 
-from llama_index.readers.llamahub_modules.github_repo import GithubClient, GithubRepositoryReader
+from llama_hub.github_repo import GithubClient, GithubRepositoryReader
 
 docs = None
 if os.path.exists("docs.pkl"):

--- a/llama_hub/github_repo/base.py
+++ b/llama_hub/github_repo/base.py
@@ -35,14 +35,14 @@ if "pytest" in sys.modules:
         get_file_extension,
     )
 else:
-    from llama_index.readers.llamahub_modules.github_repo.github_client import (
+    from llama_hub.github_repo.github_client import (
         BaseGithubClient,
         GithubClient,
         GitBranchResponseModel,
         GitCommitResponseModel,
         GitTreeResponseModel,
     )
-    from llama_index.readers.llamahub_modules.github_repo.utils import (
+    from llama_hub.github_repo.utils import (
         BufferedGitBlobDataIterator,
         print_if_verbose,
         get_file_extension,

--- a/llama_hub/github_repo/utils.py
+++ b/llama_hub/github_repo/utils.py
@@ -17,7 +17,7 @@ if "pytest" in sys.modules:
         GitTreeResponseModel,
     )
 else:
-    from llama_index.readers.llamahub_modules.github_repo.github_client import (
+    from llama_hub.github_repo.github_client import (
         GitBlobResponseModel,
         GithubClient,
         GitTreeResponseModel,


### PR DESCRIPTION
Replace:
`llama_index.readers.llamahub_modules.github_repo`
with 
`llama_hub.github_repo`

This fixes the error: 
```
Traceback (most recent call last):
  File "test.py", line 4, in <module>
    from llama_hub.github_repo import GithubRepositoryReader, GithubClient
  File "/.../llama_hub/github_repo/__init__.py", line 3, in <module>
    from .base import GithubRepositoryReader
  File "/.../llama_hub/github_repo/base.py", line 38, in <module>
    from llama_index.readers.llamahub_modules.github_repo.github_client import (
ModuleNotFoundError: No module named 'llama_index.readers.llamahub_modules'
```