### PR TITLE
Fix `github_repo` example

### DIFF
--- a/llama_hub/github_repo/README.md
+++ b/llama_hub/github_repo/README.md
@@ -83,5 +83,7 @@ if docs is None:
 
 index = GPTVectorStoreIndex.from_documents(docs)
 
-index.query("Explain each LlamaIndex class?")
+query_engine = index.as_query_engine()
+response = query_engine.query("Explain each LlamaIndex class?")
+print(response)
 ```


### PR DESCRIPTION
The example on https://llamahub.ai/l/github_repo is outdated, so I've updated the example to show correct usage.