### PR TITLE
Fixed `ValueError: Metadata key must be str! error` in Hubspot loader

### DIFF
--- a/llama_hub/hubspot/base.py
+++ b/llama_hub/hubspot/base.py
@@ -31,8 +31,8 @@ class HubspotReader(BaseReader):
         all_contacts = api_client.crm.contacts.get_all()
         all_companies = api_client.crm.companies.get_all()
         results = [
-            Document(f"{all_deals}".replace("\n", ""), extra_info={type: "deals"}), 
-            Document(f"{all_contacts}".replace("\n", ""), extra_info={type: "contacts"}),
-            Document(f"{all_companies}".replace("\n", ""), extra_info={type: "companies"})
+            Document(f"{all_deals}".replace("\n", ""), extra_info={"type": "deals"}), 
+            Document(f"{all_contacts}".replace("\n", ""), extra_info={"type": "contacts"}),
+            Document(f"{all_companies}".replace("\n", ""), extra_info={"type": "companies"})
         ]
         return results


### PR DESCRIPTION
The Hubspot loader doesn't work at the moment. This PR is to fix the raised error `ValueError: Metadata key must be str!`. 