### PR TITLE
support Confluence personal access token

### DIFF
--- a/llama_hub/confluence/README.md
+++ b/llama_hub/confluence/README.md
@@ -3,7 +3,7 @@
 This loader loads pages from a given Confluence cloud instance. The user needs to specify the base URL for a Confluence 
 instance to initialize the ConfluenceReader - base URL needs to end with `/wiki`. The user can optionally specify 
 OAuth 2.0 credentials to authenticate with the Confluence instance. If no credentials are specified, the loader will
-look for `CONFLUENCE_USERNAME` and `CONFLUENCE_API_TOKEN` environment variables to proceed with basic authentication.
+look for `CONFLUENCE_API_TOKEN` or `CONFLUENCE_USERNAME`/`CONFLUENCE_PASSWORD` environment variables to proceed with basic authentication.
 
 For more on authenticating using OAuth 2.0, checkout:
 - https://atlassian-python-api.readthedocs.io/index.html

--- a/tests/tests_confluence/test_confluence_reader.py
+++ b/tests/tests_confluence/test_confluence_reader.py
@@ -25,13 +25,13 @@ class TestConfluenceReader:
 
         # Test with oauth2
         ConfluenceReader(base_url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH)
-        mock_confluence.assert_called_once_with(
+        mock_confluence.assert_called_with(
             url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH, cloud=True
         )
 
         # Test with oauth2 and not cloud
         ConfluenceReader(base_url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH, cloud=False)
-        mock_confluence.assert_called_once_with(
+        mock_confluence.assert_called_with(
             url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH, cloud=False
         )
 

--- a/tests/tests_confluence/test_confluence_reader.py
+++ b/tests/tests_confluence/test_confluence_reader.py
@@ -29,16 +29,34 @@ class TestConfluenceReader:
             url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH, cloud=True
         )
 
-        # Test without oauth2
+        # Test with oauth2 and not cloud
+        ConfluenceReader(base_url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH, cloud=False)
+        mock_confluence.assert_called_once_with(
+            url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH, cloud=False
+        )
+
+        # Test with api token
         with unittest.mock.patch.dict(
             "os.environ",
-            {"CONFLUENCE_USERNAME": "user", "CONFLUENCE_API_TOKEN": "api_token"},
+            {"CONFLUENCE_API_TOKEN": "api_token"},
+        ):
+            ConfluenceReader(base_url=CONFLUENCE_BASE_URL)
+            mock_confluence.assert_called_with(
+                url=CONFLUENCE_BASE_URL,
+                token="api_token",
+                cloud=True,
+            )
+
+        # Test with basic auth
+        with unittest.mock.patch.dict(
+            "os.environ",
+            {"CONFLUENCE_USERNAME": "user", "CONFLUENCE_PASSWORD": "password"},
         ):
             ConfluenceReader(base_url=CONFLUENCE_BASE_URL)
             mock_confluence.assert_called_with(
                 url=CONFLUENCE_BASE_URL,
                 username="user",
-                password="api_token",
+                password="password",
                 cloud=True,
             )
 


### PR DESCRIPTION
Existing support for Confluence basic auth lacks popular option of providing personal access token.

This PR changes behavior of CONFLUENCE_API_TOKEN environment variable, which is used to provide user's password, for this purpose new environment variable CONFLUENCE_PASSWORD is now supported.

Additionally, inner Confluence API is able to support self-hosted (not Atlassian Cloud) instances just fine, for that I've added `cloud` bool argument, defaults to True to preserve current behavior.