### PR TITLE
confluence.load_data new features, bug fixes, tests

### DIFF
--- a/llama_hub/confluence/README.md
+++ b/llama_hub/confluence/README.md
@@ -9,10 +9,20 @@ For more on authenticating using OAuth 2.0, checkout:
 - https://atlassian-python-api.readthedocs.io/index.html
 - https://developer.atlassian.com/cloud/confluence/oauth-2-3lo-apps/
 
-User then specify a list of `page_ids` and/or `space_key` to load in the corresponding pages into Document objects, if 
-both are specified the union of both sets will be returned. User can also specify a boolean `include_attachments` to 
+Confluence pages are obtained through one of 4 four mutually exclusive ways:
+
+1. `page_ids`: Load all pages from a list of page ids
+2. `space_key`: Load all pages from a space
+3. `label`: Load all pages with a given label
+4. `cql`: Load all pages that match a given CQL query (Confluence Query Language https://developer.atlassian.com/cloud/confluence/advanced-searching-using-cql/ ).
+
+When `page_ids` is specified, `include_children` will cause the loader to also load all descendent pages.
+When `space_key` is specified, `page_status` further specifies the status of pages to load.
+
+User can also specify a boolean `include_attachments` to 
 include attachments, this is set to `False` by default, if set to `True` all attachments will be downloaded and 
-ConfluenceReader will extract the text from the attachments and add it to the Document object. Currently supported attachment types are: PDF, PNG, JPEG/JPG, SVG, Word and Excel. 
+ConfluenceReader will extract the text from the attachments and add it to the Document object.
+Currently supported attachment types are: PDF, PNG, JPEG/JPG, SVG, Word and Excel. 
 
 Hint: `space_key` and `page_id` can both be found in the URL of a page in Confluence - https://yoursite.atlassian.com/wiki/spaces/<space_key>/pages/<page_id>
 
@@ -23,7 +33,7 @@ Here's an example usage of the ConfluenceReader.
 ```python
 from llama_index import download_loader
 
-ConfluenceReader = download_loader('ConfluenceReader')
+ConfluenceReader = download_loader('ConfluenceReader', refresh_cache=True)
 
 token = {
     access_token: "<access_token>",
@@ -40,7 +50,8 @@ page_ids = ["<page_id_1>", "<page_id_2>", "<page_id_3"]
 space_key = "<space_key>"
 
 reader = ConfluenceReader(base_url=base_url, oauth2=oauth2_dict)
-documents = reader.load_data(space_key=space_key, page_ids=page_ids, include_attachments=True)
+documents = reader.load_data(space_key=space_key, include_attachments=True, page_status="current")
+documents.extend(reader.load_data(page_ids=page_ids, include_children=True, include_attachments=True))
 ```
 
 This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/jerryjliu/gpt_index/tree/main/gpt_index) and/or subsequently used as a Tool in a [LangChain](https://github.com/hwchase17/langchain) Agent. See [here](https://github.com/emptycrown/llama-hub/tree/main) for examples.

--- a/llama_hub/confluence/README.md
+++ b/llama_hub/confluence/README.md
@@ -17,7 +17,11 @@ Confluence pages are obtained through one of 4 four mutually exclusive ways:
 4. `cql`: Load all pages that match a given CQL query (Confluence Query Language https://developer.atlassian.com/cloud/confluence/advanced-searching-using-cql/ ).
 
 When `page_ids` is specified, `include_children` will cause the loader to also load all descendent pages.
-When `space_key` is specified, `page_status` further specifies the status of pages to load.
+When `space_key` is specified, `page_status` further specifies the status of pages to load: None, 'current', 'archived', 'draft'.
+
+limit (int): Deprecated, use `max_num_results` instead.
+
+max_num_results (int): Maximum number of results to return.  If None, return all results.  Requests are made in batches to achieve the desired number of results.
 
 User can also specify a boolean `include_attachments` to 
 include attachments, this is set to `False` by default, if set to `True` all attachments will be downloaded and 

--- a/llama_hub/confluence/base.py
+++ b/llama_hub/confluence/base.py
@@ -167,7 +167,7 @@ class ConfluenceReader(BaseReader):
                 max_num_remaining -= len(results)
         return ret
 
-    @retry(stop_max_attempt_number=4, wait_exponential_multiplier=1000)
+    @retry(stop_max_attempt_number=4, wait_fixed=4000)
     def _get_data_with_retry(self, function, **kwargs):
         return function(**kwargs)
 

--- a/llama_hub/confluence/base.py
+++ b/llama_hub/confluence/base.py
@@ -57,14 +57,14 @@ class ConfluenceReader(BaseReader):
                   page_status: Optional[str] = None, label: Optional[str] = None, cql: Optional[str] = None,
                   include_attachments=False, include_children=False, limit: Optional[int] = None,
                   max_num_results: Optional[int] = None) -> List[Document]:
-        """Load Confluence pages from Confluence, specifying by one of four mutually exlusive methods:
+        """Load Confluence pages from Confluence, specifying by one of four mutually exclusive methods:
         `space_key`, `page_ids`, `label`, or `cql`
         (Confluence Query Language https://developer.atlassian.com/cloud/confluence/advanced-searching-using-cql/ ).
 
         Args:
             space_key (str): Confluence space key, eg 'DS'
             page_ids (list): List of page ids, eg ['123456', '123457']
-            page_status (str): Page status, one of 'any', 'current', 'draft', 'archived'.  Only compatible with space_key.
+            page_status (str): Page status, one of None (all statuses), 'current', 'draft', 'archived'.  Only compatible with space_key.
             label (str): Confluence label, eg 'my-label'
             cql (str): Confluence Query Language query, eg 'label="my-label"'
             include_attachments (bool): If True, include attachments.

--- a/llama_hub/confluence/base.py
+++ b/llama_hub/confluence/base.py
@@ -80,7 +80,7 @@ class ConfluenceReader(BaseReader):
         if space_key:
             pages.extend(self._get_data_with_paging(self.confluence.get_all_pages_from_space,
                                                     max_num_results=max_num_results,
-                                                    space=space_key, page_status=page_status,
+                                                    space=space_key, status=page_status,
                                                     expand='body.storage.value'))
         if label:
             pages.extend(self._get_data_with_paging(self.confluence.cql, max_num_results=max_num_results,

--- a/llama_hub/confluence/base.py
+++ b/llama_hub/confluence/base.py
@@ -1,5 +1,6 @@
 """Confluence reader."""
 import os
+from retrying import retry
 from typing import List, Optional, Dict
 
 from llama_index.readers.base import BaseReader
@@ -51,82 +52,88 @@ class ConfluenceReader(BaseReader):
             self.confluence = Confluence(url=base_url, username=user_name, password=api_token, cloud=True)
 
     def load_data(self, space_key: Optional[str] = None, page_ids: Optional[List[str]] = None,
-                  label: Optional[str] = None, cql: Optional[str] = None, include_attachments=False,
-                  include_children=False, limit = 50) -> List[Document]:
+                  page_status: Optional[str] = None, label: Optional[str] = None, cql: Optional[str] = None,
+                  include_attachments=False, include_children=False, limit=50) -> List[Document]:
         if not space_key and not page_ids and not label and not cql:
             raise ValueError("Must specify at least one among `space_key`, `page_ids`, `label`, `cql` parameters.")
+        if page_status and not space_key:
+            raise ValueError("Must specify `space_key` when `page_status` is specified.")
 
         try:
             import html2text  # type: ignore
         except ImportError:
             raise ImportError("`html2text` package not found, please run `pip install html2text`")
 
-        docs = []
-
         text_maker = html2text.HTML2Text()
         text_maker.ignore_links = True
         text_maker.ignore_images = True
 
+        pages: List = []
         if space_key:
-            # Don't just query all the pages since the number of pages can be very large
-            # instead we can page through them
-            start = 0
-            pages = []
-            while True:
-                pages_iter = self.confluence.get_all_pages_from_space(space_key, start=start, limit=limit, expand='body.storage.value')
-
-                if len(pages_iter) == 0:
-                    break
-
-                start += len(pages_iter)
-                pages.extend(pages_iter)
-
-                # no more to fetch
-                if len(pages_iter) < limit:
-                    break
-
-            for page in pages:
-                doc = self.process_page(page, include_attachments, text_maker)
-                docs.append(doc)
-
+            pages.extend(self._get_data_with_paging(self.confluence.get_all_pages_from_space, limit_total=limit,
+                                                    space=space_key, page_status=page_status,
+                                                    expand='body.storage.value'))
         if label:
-            pages = self.confluence.get_all_pages_by_label(label=label, limit=limit, expand='body.storage.value')
-            for page in pages:
-                doc = self.process_page(page, include_attachments, text_maker)
-                docs.append(doc)
-
+            pages.extend(self._get_data_with_paging(self.confluence.cql, limit_total=limit,
+                                                    cql=f'type="page" AND label="{label}"',
+                                                    expand='body.storage.value'))
         if cql:
-            pages = self.confluence.cql(cql=cql, limit=limit, expand='body.storage.value')
-            for page in pages:
-                doc = self.process_page(page, include_attachments, text_maker)
-                docs.append(doc)
-
-        if label:
-            pages = self.confluence.get_all_pages_by_label(label=label, expand='body.storage.value')
-            for page in pages:
-                doc = self.process_page(page, include_attachments, text_maker)
-                docs.append(doc)
-
+            pages.extend(self._get_data_with_paging(self.confluence.cql, limit_total=limit, cql=cql,
+                                                    expand='body.storage.value'))
         if page_ids:
-            # with the include children option we will dfs and get the children of all the pages 
-            # requested
             if include_children:
-                page_ids = self._dfs_page(self.confluence, page_ids[0])
+                dfs_page_ids = []
+                limit_subtotal = limit
+                for page_id in page_ids:
+                    current_dfs_page_ids = self._dfs_page_ids(page_id, limit_subtotal)
+                    dfs_page_ids.extend = current_dfs_page_ids
+                    limit_subtotal -= len(current_dfs_page_ids)
+                    if limit_subtotal <= 0:
+                        break
+                page_ids = dfs_page_ids
             for page_id in page_ids:
-                page = self.confluence.get_page_by_id(page_id=page_id, expand='body.storage.value')
-                doc = self.process_page(page, include_attachments, text_maker)
-                docs.append(doc)
+                pages.append(self._get_data_with_retry(self.confluence.get_page_by_id, page_id=page_id,
+                                                       expand='body.storage.value'))
+
+        docs = []
+        for page in pages:
+            doc = self.process_page(page, include_attachments, text_maker)
+            docs.append(doc)
 
         return docs
 
-    def _dfs_page(self, raw_confluence, page_id):
-        ret = []
-        ret += [page_id]
-        pages = self.confluence.get_page_child_by_type(page_id,  type='page', start=None, limit=None, expand=None)
-        ids = [page['id'] for page in pages]
-        for id in ids:
-            ret += self._dfs_page(raw_confluence, id)
+    def _dfs_page_ids(self, page_id, limit_total):
+        ret = [page_id]
+        limit_subtotal = limit_total - 1
+        if limit_subtotal <= 0:
+            return ret
+
+        child_page_ids = self._get_data_with_paging(self.confluence.get_child_id_list, page_id=page_id, type='page',
+                                                    limit_total=limit_subtotal)
+        for id in child_page_ids:
+            dfs_ids = self._dfs_page_ids(id, limit_subtotal)
+            limit_subtotal -= len(dfs_ids)
+            ret.extend(dfs_ids)
+            if limit_subtotal <= 0:
+                break
         return ret
+
+    def _get_data_with_paging(self, paged_function, limit_total=50, **kwargs):
+        start = 0
+        limit = limit_total
+        ret = []
+        while True:
+            results = self._get_data_with_retry(paged_function, start=start, limit=limit, **kwargs)
+            if len(results) == 0 or len(results) >= limit:
+                break
+            start += len(results)
+            limit -= len(results)
+            ret.extend(results)
+        return ret
+
+    @retry(stop_max_attempt_number=3, wait_exponential_multiplier=1000)
+    def _get_data_with_retry(self, function, **kwargs):
+        return function(**kwargs)
 
     def process_page(self, page, include_attachments, text_maker):
         if include_attachments:

--- a/llama_hub/confluence/base.py
+++ b/llama_hub/confluence/base.py
@@ -57,8 +57,14 @@ class ConfluenceReader(BaseReader):
                   page_status: Optional[str] = None, label: Optional[str] = None, cql: Optional[str] = None,
                   include_attachments=False, include_children=False, limit: Optional[int] = None,
                   max_num_results: Optional[int] = None) -> List[Document]:
-        if not space_key and not page_ids and not label and not cql:
-            raise ValueError("Must specify at least one among `space_key`, `page_ids`, `label`, `cql` parameters.")
+
+        num_space_key_parameter = 1 if space_key else 0
+        num_page_ids_parameter = 1 if page_ids is not None else 0
+        num_label_parameter = 1 if label else 0
+        num_cql_parameter = 1 if cql else 0
+        if num_space_key_parameter + num_page_ids_parameter + num_label_parameter + num_cql_parameter != 1:
+            raise ValueError("Must specify exactly one among `space_key`, `page_ids`, `label`, `cql` parameters.")
+
         if page_status and not space_key:
             raise ValueError("Must specify `space_key` when `page_status` is specified.")
 
@@ -82,14 +88,14 @@ class ConfluenceReader(BaseReader):
                                                     max_num_results=max_num_results,
                                                     space=space_key, status=page_status,
                                                     expand='body.storage.value', content_type='page'))
-        if label:
+        elif label:
             pages.extend(self._get_data_with_paging(self.confluence.cql, max_num_results=max_num_results,
                                                     cql=f'type="page" AND label="{label}"',
                                                     expand='body.storage.value'))
-        if cql:
+        elif cql:
             pages.extend(self._get_data_with_paging(self.confluence.cql, max_num_results=max_num_results, cql=cql,
                                                     expand='body.storage.value'))
-        if page_ids:
+        elif page_ids:
             if include_children:
                 dfs_page_ids = []
                 max_num_remaining = max_num_results

--- a/llama_hub/confluence/base.py
+++ b/llama_hub/confluence/base.py
@@ -64,7 +64,7 @@ class ConfluenceReader(BaseReader):
         Args:
             space_key (str): Confluence space key, eg 'DS'
             page_ids (list): List of page ids, eg ['123456', '123457']
-            page_status (str): Page status, eg 'any', 'current', 'archived', etc.  Only compatible with space_key.
+            page_status (str): Page status, one of 'any', 'current', 'draft', 'archived'.  Only compatible with space_key.
             label (str): Confluence label, eg 'my-label'
             cql (str): Confluence Query Language query, eg 'label="my-label"'
             include_attachments (bool): If True, include attachments.

--- a/llama_hub/confluence/base.py
+++ b/llama_hub/confluence/base.py
@@ -57,6 +57,21 @@ class ConfluenceReader(BaseReader):
                   page_status: Optional[str] = None, label: Optional[str] = None, cql: Optional[str] = None,
                   include_attachments=False, include_children=False, limit: Optional[int] = None,
                   max_num_results: Optional[int] = None) -> List[Document]:
+        """Load Confluence pages from Confluence, specifying by one of four mutually exlusive methods:
+        `space_key`, `page_ids`, `label`, or `cql`
+        (Confluence Query Language https://developer.atlassian.com/cloud/confluence/advanced-searching-using-cql/ ).
+
+        Args:
+            space_key (str): Confluence space key, eg 'DS'
+            page_ids (list): List of page ids, eg ['123456', '123457']
+            page_status (str): Page status, eg 'any', 'current', 'archived', etc.  Only compatible with space_key.
+            label (str): Confluence label, eg 'my-label'
+            cql (str): Confluence Query Language query, eg 'label="my-label"'
+            include_attachments (bool): If True, include attachments.
+            include_children (bool): If True, do a DFS of the descendants of each page_id in `page_ids`.  Only compatible with `page_ids`.
+            limit (int): Deprecated, use `max_num_results` instead.
+            max_num_results (int): Maximum number of results to return.  If None, return all results.  Requests are made in batches to achieve the desired number of results.
+        """
 
         num_space_key_parameter = 1 if space_key else 0
         num_page_ids_parameter = 1 if page_ids is not None else 0
@@ -67,6 +82,9 @@ class ConfluenceReader(BaseReader):
 
         if page_status and not space_key:
             raise ValueError("Must specify `space_key` when `page_status` is specified.")
+
+        if include_children and not page_ids:
+            raise ValueError("Must specify `page_ids` when `include_children` is specified.")
 
         if limit is not None:
             max_num_results = limit

--- a/llama_hub/confluence/base.py
+++ b/llama_hub/confluence/base.py
@@ -174,7 +174,7 @@ class ConfluenceReader(BaseReader):
         ret = []
         cursor = None
         while True:
-            results = self._get_data_with_retry(self.confluence.get, params={'cql': cql, 'start': start,
+            results = self._get_data_with_retry(self.confluence.get, 'rest/api/search', params={'cql': cql, 'start': start,
                                                                              'limit': max_num_remaining,
                                                                              'cursor': cursor, 'expand': expand})
             ret.extend(results['results'])

--- a/llama_hub/confluence/base.py
+++ b/llama_hub/confluence/base.py
@@ -174,7 +174,7 @@ class ConfluenceReader(BaseReader):
         ret = []
         cursor = None
         while True:
-            results = self._get_data_with_retry(self.confluence.get, 'rest/api/search', params={'cql': cql, 'start': start,
+            results = self._get_data_with_retry(self.confluence.get, path='rest/api/search', params={'cql': cql, 'start': start,
                                                                              'limit': max_num_remaining,
                                                                              'cursor': cursor, 'expand': expand})
             ret.extend(results['results'])

--- a/llama_hub/confluence/requirements.txt
+++ b/llama_hub/confluence/requirements.txt
@@ -6,3 +6,4 @@ Pillow
 docx2txt
 xlrd
 svglib
+retrying

--- a/tests/tests_confluence/test_confluence_reader.py
+++ b/tests/tests_confluence/test_confluence_reader.py
@@ -357,7 +357,6 @@ class TestConfluenceReader:
         assert all(isinstance(doc, Document) for doc in documents)
         assert [doc.doc_id for doc in documents] == mock_page_ids
 
-# TODO: test for when we call more than one type of getting method.  label cql, etc.
     def test_confluence_reader_load_data_dfs(self, mock_confluence):
         mock_confluence.get_child_id_list.side_effect = _mock_get_child_id_list
         mock_confluence.get_page_by_id.side_effect = lambda page_id, expand: \

--- a/tests/tests_confluence/test_confluence_reader.py
+++ b/tests/tests_confluence/test_confluence_reader.py
@@ -42,7 +42,7 @@ class TestConfluenceReader:
                 cloud=True,
             )
 
-    def test_confluence_reader_load_data_invalid_args(self, mock_confluence):
+    def test_confluence_reader_load_data_invalid_args_no_method(self, mock_confluence):
         confluence_reader = ConfluenceReader(
             base_url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH
         )
@@ -50,9 +50,21 @@ class TestConfluenceReader:
 
         with pytest.raises(
             ValueError,
-            match="Must specify at least one among `space_key`, `page_ids`, `label`, `cql` parameters.",
+            match="Must specify exactly one among `space_key`, `page_ids`, `label`, `cql` parameters.",
         ):
             confluence_reader.load_data()
+
+    def test_confluence_reader_load_data_invalid_args_multiple_methods(self, mock_confluence):
+        confluence_reader = ConfluenceReader(
+            base_url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH
+        )
+        confluence_reader.confluence = mock_confluence
+
+        with pytest.raises(
+                ValueError,
+                match="Must specify exactly one among `space_key`, `page_ids`, `label`, `cql` parameters.",
+        ):
+            confluence_reader.load_data(space_key="123", page_ids=["123"])
 
     def test_confluence_reader_load_data_invalid_args_page_status_no_space_key(self, mock_confluence):
         confluence_reader = ConfluenceReader(
@@ -65,6 +77,18 @@ class TestConfluenceReader:
             match="Must specify `space_key` when `page_status` is specified.",
         ):
             confluence_reader.load_data(page_status="current", page_ids=["123"])
+
+    def test_confluence_reader_load_data_invalid_args_include_children_page_ids(self, mock_confluence):
+        confluence_reader = ConfluenceReader(
+            base_url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH
+        )
+        confluence_reader.confluence = mock_confluence
+
+        with pytest.raises(
+                ValueError,
+                match="Must specify `page_ids` when `include_children` is specified.",
+        ):
+            confluence_reader.load_data(space_key="123", include_children=True)
 
     def test_confluence_reader_load_data_by_page_ids(self, mock_confluence):
         mock_confluence.get_page_by_id.side_effect = [

--- a/tests/tests_confluence/test_confluence_reader.py
+++ b/tests/tests_confluence/test_confluence_reader.py
@@ -282,6 +282,82 @@ class TestConfluenceReader:
         assert all(isinstance(doc, Document) for doc in documents)
         assert all(documents[i].doc_id == str(i) for i in range(8))
 
+    def test_confluence_reader_load_data_by_page_ids_max_10(self, mock_confluence):
+        mock_confluence.get_page_by_id.side_effect = lambda page_id, expand: \
+            {
+                "id": str(page_id),
+                "type": "page",
+                "status": "current",
+                "title": f"Page {page_id}",
+                "body": {"storage": {"value": f"<p>Content {page_id}</p>"}},
+            }
+
+        confluence_reader = ConfluenceReader(
+            base_url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH
+        )
+        confluence_reader.confluence = mock_confluence
+
+        mock_page_ids = ["0", "1", "2", "3", "4", "5", "6", "7"]
+        mock_get_children = False
+        mock_max_num_results = 10 # Asking for up to 10 pages, but only requesting 8 specific ones.
+        documents = confluence_reader.load_data(page_ids=mock_page_ids, include_children=mock_get_children, max_num_results=mock_max_num_results)
+
+        assert mock_confluence.get_page_by_id.call_count == 8
+        assert len(documents) == 8
+        assert all(isinstance(doc, Document) for doc in documents)
+        assert [doc.doc_id for doc in documents] == mock_page_ids
+
+    def test_confluence_reader_load_data_by_page_ids_max_5(self, mock_confluence):
+        mock_confluence.get_page_by_id.side_effect = lambda page_id, expand: \
+            {
+                "id": str(page_id),
+                "type": "page",
+                "status": "current",
+                "title": f"Page {page_id}",
+                "body": {"storage": {"value": f"<p>Content {page_id}</p>"}},
+            }
+
+        confluence_reader = ConfluenceReader(
+            base_url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH
+        )
+        confluence_reader.confluence = mock_confluence
+
+        mock_page_ids = ["0", "1", "2", "3", "4", "5", "6", "7"]
+        mock_get_children = False
+        mock_max_num_results = 5 # Asking for up to 5 pages
+        documents = confluence_reader.load_data(page_ids=mock_page_ids, include_children=mock_get_children, max_num_results=mock_max_num_results)
+
+        assert mock_confluence.get_page_by_id.call_count == 5
+        assert len(documents) == 5
+        assert all(isinstance(doc, Document) for doc in documents)
+        assert [doc.doc_id for doc in documents] == mock_page_ids[:5]
+
+    def test_confluence_reader_load_data_by_page_ids_max_5(self, mock_confluence):
+        mock_confluence.get_page_by_id.side_effect = lambda page_id, expand: \
+            {
+                "id": str(page_id),
+                "type": "page",
+                "status": "current",
+                "title": f"Page {page_id}",
+                "body": {"storage": {"value": f"<p>Content {page_id}</p>"}},
+            }
+
+        confluence_reader = ConfluenceReader(
+            base_url=CONFLUENCE_BASE_URL, oauth2=MOCK_OAUTH
+        )
+        confluence_reader.confluence = mock_confluence
+
+        mock_page_ids = ["0", "1", "2", "3", "4", "5", "6", "7"]
+        mock_get_children = False
+        mock_max_num_results = None
+        documents = confluence_reader.load_data(page_ids=mock_page_ids, include_children=mock_get_children, max_num_results=mock_max_num_results)
+
+        assert mock_confluence.get_page_by_id.call_count == 8
+        assert len(documents) == 8
+        assert all(isinstance(doc, Document) for doc in documents)
+        assert [doc.doc_id for doc in documents] == mock_page_ids
+
+# TODO: test for when we call more than one type of getting method.  label cql, etc.
     def test_confluence_reader_load_data_dfs(self, mock_confluence):
         mock_confluence.get_child_id_list.side_effect = _mock_get_child_id_list
         mock_confluence.get_page_by_id.side_effect = lambda page_id, expand: \


### PR DESCRIPTION
A number of enhancements to the confluence `load_data` function, as follows:

- Add `retrying` as dependency.
- GET requests to Confluence API are done with `retrying` to reduce chances of one of them killing batches.
- Fix bug(s)s in paged GET requests. (see Additional Information).
- Implement paged GET requests for cql and labels.
- Add more argument validation.
- Deprecate `limit` parameter in favour of unambiguous `max_num_results` parameter.
- Implement `max_num_results` for every retrieval method (cql, label, page_ids, include_child_pages, `space_key`)
- Make the different retrieval methods mutually exclusive (I can't think of when you would want the union of different retrieval methods, and that complicates the use of `max_num_results`, plus it's easy to call it once for each retrieval method you are interested in).
- Refactored to remove repeated code.
- Added many tests, including for DFS, and both paging methods, plus the additional arg validation.
- Added documentation for the changed behaviour.

There are some breaking changes here, but I think it's unlikely that anyone is relying on the confluence hub in production, and it should continue to work fine in demos for every use case except multiple retrieval methods.

## Additional Information

Confluence API uses start and limit parameters for getting batches of content, but usually there is also an (unknown) server limit (50,200,500?).  We also may want to bound the number of results if we are trying to test a request that can get many results.  To avoid confusion between these different types of "limits", `load_data` offers `max_num_results`, and always tries to get as many results in one request as possible, but then inspects the number of results returned before deciding whether to request more with a new `start` and a new `limit=max_num_remaining`.

Previously, paged requests were not implemented for label and cql queries, and now they are.  Furthermore, previously it was possible to get fewer results than those requested via the now deprecated `limit` parameter if the `limit` parameter was greater than the (usually unknown) server limit.
