### PR TITLE
Add extra info to web

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ retrying = "*"
 [tool.poetry.dev-dependencies]
 pytest = "7.2.1"
 pytest-dotenv = "0.5.2"
+pytest_httpserver = "1.0.8"
 typing-inspect = "0.8.0"
 typing_extensions = "4.5.0"
 types-requests = "2.28.11.8"

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,6 +2,7 @@
 # For testing
 pytest==7.2.1
 pytest-dotenv==0.5.2
+pytest_httpserver==1.0.8
 
 # pin types
 typing-inspect==0.8.0

--- a/tests/tests_web_async_web/test_web_async_web_reader.py
+++ b/tests/tests_web_async_web/test_web_async_web_reader.py
@@ -1,0 +1,84 @@
+import pytest
+import unittest
+from llama_hub.web.async_web.base import AsyncWebPageReader
+from werkzeug.wrappers import Response, Request
+
+
+@pytest.fixture(scope="session")
+def httpserver_listen_address():
+    return ("localhost", 8888)
+
+
+TEST_URL = 'http://localhost:8888/primary.xml'
+TEST_URL_OTHER = 'http://localhost:8888/other.xml'
+TEST_URL_ERROR = 'http://localhost:8888/failme'
+
+
+class TestAsyncWebPageReader(unittest.TestCase):
+
+    def failme_handler(self, response: Request):
+        return Response('Boo!', status=500)
+
+    @pytest.fixture(autouse=True)
+    def setup(self, httpserver):
+        httpserver.expect_request('/other.xml', method="GET").respond_with_data("Some big data chunk!")
+        httpserver.expect_request('/failme', method="GET").respond_with_handler(self.failme_handler)
+        httpserver.expect_request('/primary.xml', method="GET").respond_with_data("Some big data chunk!")
+    
+    def test_async_web_reader_init(self):
+
+        # test w/o args
+        AsyncWebPageReader()
+
+        # test w args
+        AsyncWebPageReader(html_to_text=True, limit=50)
+
+    def test_async_web_reader_load_data_invalid_args(self):
+        reader = AsyncWebPageReader()
+ 
+        with pytest.raises(
+            TypeError,
+            match="missing 1 required positional argument: 'urls'",
+        ):
+            reader.load_data()
+
+    def test_async_web_reader_load_data(self):
+        
+        reader = AsyncWebPageReader()
+
+        documents = reader.load_data(urls=[TEST_URL])
+
+        assert len(documents) == 1
+        assert documents[0].text == 'Some big data chunk!' 
+        assert documents[0].extra_info['Source'] == 'http://localhost:8888/primary.xml' 
+    
+    def test_async_web_reader_load_data_consume_error(self):
+        
+        reader = AsyncWebPageReader()
+
+        documents = reader.load_data(urls=[TEST_URL_ERROR])
+
+        assert len(documents) == 0
+
+    def test_async_web_reader_load_data_raise_error(self):
+        
+        reader = AsyncWebPageReader(fail_on_error=True)
+
+        with pytest.raises(
+            ValueError,
+            match="error fetching page from http://localhost:8888/failme. server returned status: 500 and response Boo!"
+        ):
+            reader.load_data(urls=[TEST_URL_ERROR])
+
+
+    def test_async_web_reader_load_data_dedupe(self):
+        
+        reader = AsyncWebPageReader(dedupe=True)
+
+        documents = reader.load_data(urls=[TEST_URL, TEST_URL_OTHER, TEST_URL])
+
+        assert len(documents) == 2
+        assert documents[0].text == 'Some big data chunk!' 
+        assert documents[0].extra_info['Source'] == 'http://localhost:8888/primary.xml'
+        assert documents[1].text == 'Some big data chunk!'
+        assert documents[1].extra_info['Source'] == 'http://localhost:8888/other.xml'

--- a/tests/tests_web_sitemap/test_web_sitemap_reader.py
+++ b/tests/tests_web_sitemap/test_web_sitemap_reader.py
@@ -2,9 +2,9 @@ import pytest
 import unittest
 from unittest.mock import patch
 from llama_hub.web.sitemap.base import SitemapReader
+from llama_index.readers.schema.base import Document
 
-MOCK_URL = "https://gpt-index.readthedocs.io/sitemap.xml"
-
+MOCK_URL = 'https://gpt-index.readthedocs.io/sitemap.xml'
 
 def get_sitemapdata():
     f = open("tests/tests_web_sitemap/test_sitemap.xml", "r")
@@ -12,8 +12,11 @@ def get_sitemapdata():
 
 
 def dummy_load_pages(urls: str):
-    return ["Document"] * len(urls)
-
+    documents = []
+    for u in urls:
+        doc = Document(text="Bla", extra_info={"Source": u})
+        documents.append(doc)
+    return documents
 
 class TestSitemapReader(unittest.TestCase):
     def test_sitemap_reader_init(self):
@@ -77,3 +80,4 @@ class TestSitemapReader(unittest.TestCase):
             mock_response.read.assert_called_once()
             assert mock_load_data.call_count == 1
             assert len(documents) == 1
+            assert documents[0].extra_info['Source'] == 'https://gpt-index.readthedocs.io/en/latest/'


### PR DESCRIPTION
This change adds extra_info to the generated documents of AsyncWebReader

- Source information (the url called) will be added to extra_info of Document class
- deduplication feature will sort out exact same urls in given urls list
- fail on error feature will handle status codes != 200 either with raising an error or logging a warning
- added tests which introduce pytest_httpserver to simulate different situations for different urls