### PR TITLE
[bugfix] replace None to empty string to avoid TypeError

### DIFF
--- a/llama_hub/opendal_reader/azblob/base.py
+++ b/llama_hub/opendal_reader/azblob/base.py
@@ -18,9 +18,9 @@ class OpendalAzblobReader(BaseReader):
         self,
         container: str,
         path: str = "/",
-        endpoint: Optional[str] = None,
-        account_name: Optional[str] = None,
-        account_key: Optional[str] = None,
+        endpoint: str = "",
+        account_name: str = "",
+        account_key: str = "",
         file_extractor: Optional[Dict[str, Union[str, BaseReader]]] = None,
     ) -> None:
         """Initialize Azblob container, along with credentials if needed.

--- a/llama_hub/opendal_reader/gcs/base.py
+++ b/llama_hub/opendal_reader/gcs/base.py
@@ -18,8 +18,8 @@ class OpendalGcsReader(BaseReader):
         self,
         bucket: str,
         path: str = "/",
-        endpoint: Optional[str] = None,
-        credentials: Optional[str] = None,
+        endpoint: str = "",
+        credentials: str = "",
         file_extractor: Optional[Dict[str, Union[str, BaseReader]]] = None,
     ) -> None:
         """Initialize Gcs container, along with credentials if needed.

--- a/llama_hub/opendal_reader/s3/base.py
+++ b/llama_hub/opendal_reader/s3/base.py
@@ -18,10 +18,10 @@ class OpendalS3Reader(BaseReader):
         self,
         bucket: str,
         path: str = "/",
-        endpoint: Optional[str] = None,
-        region: Optional[str] = None,
-        access_key_id: Optional[str] = None,
-        secret_access_key: Optional[str] = None,
+        endpoint: str = "",
+        region: str = "",
+        access_key_id: str = "",
+        secret_access_key: str = "",
         file_extractor: Optional[Dict[str, Union[str, BaseReader]]] = None,
     ) -> None:
         """Initialize S3 bucket and key, along with credentials if needed.


### PR DESCRIPTION
Seeing the following error when you omit the params included in `self.options`
```
thread '<unnamed>' panicked at 'must be valid hashmap: PyErr { type: <class 'TypeError'>, value: TypeError("'NoneType' object cannot be converted to 'PyString'"), traceback: None }', bindings/python/src/asyncio.rs:62:22
Traceback (most recent call last):
  File "/Users/wwang/repositories/sheldon-ai/user_data_processor/main.py", line 206, in <module>
    loader = OpendalAzblobReader(
  File "/Users/wwang/Library/Python/3.9/lib/python/site-packages/llama_index/readers/llamahub_modules/opendal_reader/azblob/base.py", line 65, in load_data
    loader = OpendalReader(
  File "/Users/wwang/Library/Python/3.9/lib/python/site-packages/llama_hub/opendal_reader/base.py", line 44, in __init__
    self.op = opendal.AsyncOperator(scheme, **kwargs)
pyo3_runtime.PanicException: must be valid hashmap: PyErr { type: <class 'TypeError'>, value: TypeError("'NoneType' object cannot be converted to 'PyString'"), traceback: None }
```
Sample code to trigger this error:
```
OpendalAzblobReader = download_loader("OpendalAzblobReader")
loader = OpendalAzblobReader(
    container="bucket_name",
    path="/",
endpoint="",
account_name="",
).load_data()
```
My fix was:
```
OpendalAzblobReader = download_loader("OpendalAzblobReader")
loader = OpendalAzblobReader(
    container="bucket_name",
    path="/",
    endpoint="",
    account_name="",
    account_key="",
).load_data()
```
The same error happens with `OpendalGcsReader` and `OpendalS3Reader`