### PR TITLE
Fix body is None in Zendesk Scraper

### DIFF
--- a/llama_hub/zendesk/base.py
+++ b/llama_hub/zendesk/base.py
@@ -34,6 +34,8 @@ class ZendeskReader(BaseReader):
         articles = self.get_all_articles()
         for article in articles:
             body = article["body"]
+            if body == None:
+                continue
             soup = BeautifulSoup(body, "html.parser")
             body = soup.get_text()
             extra_info = {


### PR DESCRIPTION
Often times bs4 would error out because the body could be null in some articles. I added a quick check that solved the issue.
