### PR TITLE
feat/S3Reader Num Files Limit and expose more SimpleDirectoryReader args

### DIFF
--- a/llama_hub/s3/base.py
+++ b/llama_hub/s3/base.py
@@ -5,7 +5,7 @@ A loader that fetches a file or iterates through a directory on AWS S3.
 """
 import tempfile
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from llama_index import download_loader
 from llama_index.readers.base import BaseReader
@@ -23,6 +23,9 @@ class S3Reader(BaseReader):
         prefix: Optional[str] = "",
         file_extractor: Optional[Dict[str, Union[str, BaseReader]]] = None,
         required_exts: Optional[List[str]] = None,
+        filename_as_id: bool = False,
+        num_files_limit: Optional[int] = None,
+        file_metadata: Optional[Callable[[str], Dict]] = None,
         aws_access_id: Optional[str] = None,
         aws_access_secret: Optional[str] = None,
         aws_session_token: Optional[str] = None,
@@ -42,6 +45,13 @@ class S3Reader(BaseReader):
         file_extractor (Optional[Dict[str, BaseReader]]): A mapping of file
             extension to a BaseReader class that specifies how to convert that file
             to text. See `SimpleDirectoryReader` for more details.
+        required_exts (Optional[List[str]]): List of required extensions.
+            Default is None.
+        num_files_limit (Optional[int]): Maximum number of files to read.
+            Default is None.
+        file_metadata (Optional[Callable[str, Dict]]): A function that takes
+            in a filename and returns a Dict of metadata for the Document.
+            Default is None.
         aws_access_id (Optional[str]): provide AWS access key directly.
         aws_access_secret (Optional[str]): provide AWS access key directly.
         s3_endpoint_url (Optional[str]): provide S3 endpoint URL directly.
@@ -54,6 +64,9 @@ class S3Reader(BaseReader):
 
         self.file_extractor = file_extractor
         self.required_exts = required_exts
+        self.filename_as_id = filename_as_id
+        self.num_files_limit = num_files_limit
+        self.file_metadata = file_metadata
 
         self.aws_access_id = aws_access_id
         self.aws_access_secret = aws_access_secret
@@ -83,6 +96,9 @@ class S3Reader(BaseReader):
             else:
                 bucket = s3.Bucket(self.bucket)
                 for obj in bucket.objects.filter(Prefix=self.prefix):
+                    if self.num_files_limit is not None and self.num_files_limit > 0:
+                        break
+
                     suffix = Path(obj.key).suffix
 
                     is_dir = obj.key.endswith("/") # skip folders
@@ -102,6 +118,12 @@ class S3Reader(BaseReader):
                 from llama_index import SimpleDirectoryReader
             except ImportError:
                 SimpleDirectoryReader = download_loader("SimpleDirectoryReader")
-            loader = SimpleDirectoryReader(temp_dir, file_extractor=self.file_extractor, required_exts=self.required_exts)
+
+            loader = SimpleDirectoryReader(temp_dir,
+                                           file_extractor=self.file_extractor,
+                                           required_exts=self.required_exts,
+                                           filename_as_id=self.filename_as_id,
+                                           num_files_limit=self.num_files_limit,
+                                           file_metadata=self.file_metadata)
 
             return loader.load_data()

--- a/llama_hub/s3/base.py
+++ b/llama_hub/s3/base.py
@@ -95,8 +95,8 @@ class S3Reader(BaseReader):
                 s3_client.download_file(self.bucket, self.key, filepath)
             else:
                 bucket = s3.Bucket(self.bucket)
-                for obj in bucket.objects.filter(Prefix=self.prefix):
-                    if self.num_files_limit is not None and self.num_files_limit > 0:
+                for i, obj in enumerate(bucket.objects.filter(Prefix=self.prefix)):
+                    if self.num_files_limit is not None and i > self.num_files_limit:
                         break
 
                     suffix = Path(obj.key).suffix


### PR DESCRIPTION
## Summary

* Add the number of files limit functionality on S3Reader and forward the arg to SimpleDirectoryReader
* Expose more SimpleDirectoryReader args to S3Reader to extend it's functionality