### PR TITLE
mbox: allow passing a parser for beautifulsoup

### DIFF
--- a/llama_hub/file/mbox/README.md
+++ b/llama_hub/file/mbox/README.md
@@ -13,6 +13,10 @@ from llama_index import download_loader
 MboxReader = download_loader("MboxReader")
 documents = MboxReader().load_data(file='./email.mbox') # Returns list of documents
 
+# A different HTML parser for BeautifulSoup can be specified in the `beautifulsoup_parser` constructor argument:
+# pip install html5lib
+documents = MboxReader(beautifulsoup_parser="html5lib").load_data(file='./email.mbox') # Returns list of documents
+
 ```
 
 This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/jerryjliu/gpt_index/tree/main/gpt_index) and/or subsequently used as a Tool in a [LangChain](https://github.com/hwchase17/langchain) Agent. See [here](https://github.com/emptycrown/llama-hub/tree/main) for examples.

--- a/llama_hub/file/mbox/base.py
+++ b/llama_hub/file/mbox/base.py
@@ -32,12 +32,14 @@ class MboxReader(BaseReader):
         *args: Any,
         max_count: int = 0,
         message_format: str = DEFAULT_MESSAGE_FORMAT,
+        beautifulsoup_parser: str = 'html.parser',
         **kwargs: Any
     ) -> None:
         """Init params."""
         super().__init__(*args, **kwargs)
         self.max_count = max_count
         self.message_format = message_format
+        self.beautifulsoup_parser = beautifulsoup_parser
 
     def parse_file(self, filepath: Path, errors: str = "ignore") -> List[str]:
         """Parse file into string."""
@@ -79,7 +81,7 @@ class MboxReader(BaseReader):
                 continue
 
             # Parse message HTML content and remove unneeded whitespace
-            soup = BeautifulSoup(content)
+            soup = BeautifulSoup(content, self.beautifulsoup_parser)
             stripped_content = " ".join(soup.get_text().split())
             # Format message to include date, sender, receiver and subject
             msg_string = self.message_format.format(


### PR DESCRIPTION
 * defaults to html.parser, for other see [the BS doc](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#installing-a-parser)
 * silences the `GuessedAtParserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser")`