### PR TITLE
mbox: allow custom, stable document id

### DIFF
--- a/llama_hub/file/mbox/README.md
+++ b/llama_hub/file/mbox/README.md
@@ -14,7 +14,7 @@ MboxReader = download_loader("MboxReader")
 documents = MboxReader().load_data(file='./email.mbox') # Returns list of documents
 
 # To customize the document id, pass an id_fn. The msg argument is the whole message as defined by `message_format`
-docs = MboxReader(id_fn=lambda msg: md5(msg.encode()).hexdigest()).load_data(file=d)
+docs = MboxReader(id_fn=lambda msg: md5(msg[:200].encode()).hexdigest()).load_data(file=d)
 
 ```
 

--- a/llama_hub/file/mbox/README.md
+++ b/llama_hub/file/mbox/README.md
@@ -13,6 +13,9 @@ from llama_index import download_loader
 MboxReader = download_loader("MboxReader")
 documents = MboxReader().load_data(file='./email.mbox') # Returns list of documents
 
+# To customize the document id, pass an id_fn. The msg argument is the whole message as defined by `message_format`
+docs = MboxReader(id_fn=lambda msg: md5(msg.encode()).hexdigest()).load_data(file=d)
+
 ```
 
 This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/jerryjliu/gpt_index/tree/main/gpt_index) and/or subsequently used as a Tool in a [LangChain](https://github.com/hwchase17/langchain) Agent. See [here](https://github.com/emptycrown/llama-hub/tree/main) for examples.

--- a/llama_hub/file/mbox/base.py
+++ b/llama_hub/file/mbox/base.py
@@ -113,7 +113,7 @@ class MboxReader(BaseReader):
         for msg in content:
             d = Document(text=msg, extra_info=extra_info or {})
             if self.id_fn:
-                 d.id_ = self.id_fn(msg)
+                 d.doc_id = self.id_fn(msg)
             docs.append(d)
 
         return docs

--- a/llama_hub/file/mbox/base.py
+++ b/llama_hub/file/mbox/base.py
@@ -4,7 +4,7 @@ Contains simple parser for mbox files.
 
 """
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from llama_index.readers.base import BaseReader
 from llama_index.readers.schema.base import Document
@@ -32,12 +32,14 @@ class MboxReader(BaseReader):
         *args: Any,
         max_count: int = 0,
         message_format: str = DEFAULT_MESSAGE_FORMAT,
+        id_fn: Optional[Callable[[str], str]] = None,
         **kwargs: Any
     ) -> None:
         """Init params."""
         super().__init__(*args, **kwargs)
         self.max_count = max_count
         self.message_format = message_format
+        self.id_fn = id_fn
 
     def parse_file(self, filepath: Path, errors: str = "ignore") -> List[str]:
         """Parse file into string."""
@@ -109,5 +111,9 @@ class MboxReader(BaseReader):
         docs: List[Document] = []
         content = self.parse_file(file)
         for msg in content:
-            docs.append(Document(text=msg, extra_info=extra_info or {}))
+            d = Document(text=msg, extra_info=extra_info or {})
+            if self.id_fn:
+                 d.id_ = self.id_fn(msg)
+            docs.append(d)
+
         return docs


### PR DESCRIPTION
 * via function passed in `id_fn`, eg. `MboxReader(id_fn=lambda msg: md5(msg.encode()).hexdigest())`
 * overrides UUID-based default from Document
