### PR TITLE
Zapier Tool Spec produces a list of exposed tools

### DIFF
--- a/llama_hub/tools/zapier/base.py
+++ b/llama_hub/tools/zapier/base.py
@@ -10,7 +10,7 @@ ACTION_URL_TMPL = "https://nla.zapier.com/api/v1/dynamic/exposed/{action_id}/exe
 class ZapierToolSpec(BaseToolSpec):
     """Zapier tool spec."""
 
-    spec_functions = ["list_actions", "natural_language_query"]
+    spec_functions = []
 
     def __init__(self, api_key: Optional[str] = None, oauth_access_token: Optional[str] = None) -> None:
         """Initialize with parameters."""
@@ -25,51 +25,50 @@ class ZapierToolSpec(BaseToolSpec):
         else:
             raise ValueError("Must provide either api_key or oauth_access_token")
 
+        # Get the exposed actions from Zapier
+        actions = json.loads(self.list_actions())
+        if "results" not in actions:
+            raise ValueError("No Zapier actions exposed, visit https://nla.zapier.com/dev/actions/ to expose actions.")
+        results = actions["results"]
+
+        # Register the actions as Tools
+        for action in results:
+            params = action['params']
+
+            def function_action(id=action['id'], **kwargs):
+                return self.natural_language_query(id, **kwargs)
+
+            action_name = action['description'].split(': ')[1].replace(' ', '_')
+            function_action.__name__ = action_name
+            function_action.__doc__ = f"""
+                This is a Zapier Natural Language Action function wrapper.
+
+                The 'instructions' key is REQUIRED for all function calls.
+                The instructions key is a natural language string describing the action to be taken
+                The following are all of the valid arguments you can provide: {params}
+
+                Ignore the id field, it is provided for you.
+                If the returned error field is not null, interpret the error and try to fix it. Otherwise, inform the user of how they might fix it.
+            """
+            setattr(
+                self,
+                action_name,
+                function_action
+            )
+            self.spec_functions.append(action_name)
+
+
     def list_actions(self):
-        """
-        List the actions that the Natual Language query can complete.
-
-        All of the actions listed are accessible through the natural_language_query tool
-
-        The actions will be listed in the following format:
-
-        List[{
-                id: str,
-                description: str,
-                params: Dict[str, str]
-            }]
-
-        The params dictionary always accepts the value 'instructions'.
-        All other values in params are optional. If you provide a value for the parameter, it will override the 'instructions'.
-        Therefore, if you are not sure of the value for a param, leave it blank and prefer instead to provide more details in the 'instructions'.
-
-        However, NEVER leave instructions blank, as it is required. No other fields are required.
-        """
-
         response = requests.get(
             "https://nla.zapier.com/api/v1/dynamic/exposed/",
             headers=self._headers
         )
         return response.text
 
-
-    def natural_language_query(self, id: str, params: Dict[str, str]):
-        """
-        Make a natural language action to Zapier
-        This endpoint accepts natural language instructions to integrate with other services
-        You should always provide a natural language string in the params dict descrbing the overall action to be taken
-
-        The action being called must have an id obtained from list_actions. If the action is not exposed it can be here: 
-        Args:
-            id (str): The id of the zapier action to call
-            params (Optional[dict]): The instructions and other values instructing the action to be taken
-
-        If the error field is not null, interpret the error and try to fix it. Otherwise, inform the user of how they might fix it.
-        """
-
+    def natural_language_query(self, id: str, **kwargs):
         response = requests.post(
             ACTION_URL_TMPL.format(action_id=id),
             headers=self._headers,
-            data=json.dumps(params)
+            data=json.dumps(kwargs)
         )
         return response.text


### PR DESCRIPTION
Reimagines the zapier tool spec, removing the need to call list actions before calling the actions. 

Additionally, it takes all of the exposed actions and adds them as spec_functions to the class, allowing them to be called as normal function tools.