### PR TITLE
returning internalDate as it is more accurate

### DIFF
--- a/llama_hub/gmail/base.py
+++ b/llama_hub/gmail/base.py
@@ -143,10 +143,12 @@ class GmailReader(BaseReader, BaseModel):
         if not body:
             return None
 
+        # https://developers.google.com/gmail/api/reference/rest/v1/users.messages
         return {
             "id": message_data["id"],
             "threadId": message_data["threadId"],
             "snippet": message_data["snippet"],
+            "internalDate": message_data["internalDate"],
             "body": body,
         }
 


### PR DESCRIPTION
This PR returns the internalDate as metadata for an more accurate ordering.  The gmail api returns the emails using this as the ordering mechanism as well. 