### PR TITLE
Add url to extra_info of HatenaBlogReader

### DIFF
--- a/llama_hub/hatena_blog/base.py
+++ b/llama_hub/hatena_blog/base.py
@@ -12,6 +12,7 @@ class Article:
         self.title = ""
         self.content = ""
         self.published = ""
+        self.url = ""
 
 
 class HatenaBlogReader(BaseReader):
@@ -36,7 +37,7 @@ class HatenaBlogReader(BaseReader):
             results.append(
                 Document(
                     text=a.content,
-                    extra_info={"title": a.title, "published": a.published},
+                    extra_info={"title": a.title, "published": a.published, "url": a.url},
                 )
             )
 
@@ -71,6 +72,7 @@ class HatenaBlogReader(BaseReader):
             article = Article()
             article.title = entry.find("title").string
             article.published = entry.find("published").string
+            article.url = entry.find("link", rel="alternate")["href"]
             content = entry.find("content")
             if content.get("type") == "text/html":
                 article.content = (


### PR DESCRIPTION
I added url to extra_info when retrieving Hatena blog entries.
This is used to provide the referenced URL link after creating a response that references Hatena Blog.

There is an example response when retrieving an entry in Hatena blog on [this page](https://developer.hatena.ne.jp/ja/documents/blog/apis/atom#%E3%83%96%E3%83%AD%E3%82%B0%E3%82%A8%E3%83%B3%E3%83%88%E3%83%AA%E3%81%AE%E5%8F%96%E5%BE%97)

The following is the target of the pickup.

```
<link rel="alternate" type="text/html" href="http://{ブログID}/entry/2013/09/02/112823"/>
```
