### PR TITLE
Extending functions for DeepDoctectionReader

### DIFF
--- a/llama_hub/file/deepdoctection/README.md
+++ b/llama_hub/file/deepdoctection/README.md
@@ -1,11 +1,14 @@
 # DeepDoctection Loader
 
-This loader extracts the text from a local PDF file using the deepdoctection Python package, a library that performs
-doc extraction and document layout.
+This loader extracts the text from a local PDF file or scans using the [**deep**doctection](https://github.com/deepdoctection/deepdoctection) Python package, a library that 
+performs doc extraction and document layout. Check the [demo](https://huggingface.co/spaces/deepdoctection/deepdoctection)
+at Huggingface.
 
 ## Usage
 
-To use this loader, you need to pass in a `Path` to a local file.
+To use this loader, you need to pass in a `Path` to a local PDF-file or to a directory with image scans. 
+
+This setting extracts all text and creates for each page a `Document`:
 
 ```python
 from pathlib import Path
@@ -17,4 +20,61 @@ loader = DeepDoctectionReader()
 documents = loader.load_data(file=Path('./article.pdf'))
 ```
 
-This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/jerryjliu/gpt_index/tree/main/gpt_index) and/or subsequently used as a Tool in a [LangChain](https://github.com/hwchase17/langchain) Agent. See [here](https://github.com/emptycrown/llama-hub/tree/main) for examples.
+Creating `Document`s for layout sections will return a split based on visual components.
+
+```python
+from pathlib import Path
+from llama_index import download_loader
+
+DeepDoctectionReader = download_loader("DeepDoctectionReader")
+
+loader = DeepDoctectionReader(split_by_layout=True)
+documents = loader.load_data(file=Path('./article.pdf'))
+```
+
+Metadata on page level or layout section level can be added. The setting below will add categories like title, text,
+table and list to `Document`s metadata.
+
+```python
+from pathlib import Path
+from llama_index import download_loader
+
+DeepDoctectionReader = download_loader("DeepDoctectionReader")
+
+loader = DeepDoctectionReader(split_by_layout=True,extra_info={"category_name"})
+documents = loader.load_data(file=Path('./article.pdf'))
+```
+
+This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/jerryjliu/gpt_index/tree/main/gpt_index) and/or subsequently used as a Tool in 
+a [LangChain](https://github.com/hwchase17/langchain) Agent. See [here](https://github.com/emptycrown/llama-hub/tree/main) for examples.
+
+## Customization
+
+**Deep**doctection allows extensive customizing that affects the output subsequently. 
+ - Choice of layout models
+ - Selection of four text extraction tools (Pdfplumber and three OCR tools)
+ - Text filtering based on layout sections
+
+and many other settings.
+
+E.g. if segmenting a table is not necessary you can disable the function:
+
+```python
+from pathlib import Path
+from llama_index import download_loader
+
+DeepDoctectionReader = download_loader("DeepDoctectionReader")
+
+loader = DeepDoctectionReader(config_overwrite=['USE_TABLE_SEGMENTATION=False'])
+documents = loader.load_data(file=Path('./article.pdf'))
+```
+
+Please check the [docs](https://deepdoctection.readthedocs.io/en/latest/tutorials/analyzer_configuration_notebook/) for
+more details. 
+
+And if you still need more flexibility, you can compose your own **deep**doctection pipeline.  
+
+## Third party dependencies
+
+The default installation will install the package with minimal dependencies. Tesseract is required and needs to be installed 
+separately. If more features are required, consider a more comprehensive setup. Check the options [here](https://deepdoctection.readthedocs.io/en/latest/install/).

--- a/llama_hub/file/deepdoctection/base.py
+++ b/llama_hub/file/deepdoctection/base.py
@@ -8,31 +8,61 @@ from llama_index.readers.schema.base import Document
 
 
 class DeepDoctectionReader(BaseReader):
-    """Deepdoctection reader for pdf's.
+    """Deepdoctection reader for pdf's and image scans
 
     Uses deepdoctection as a library to parse PDF files.
 
     """
 
-    def __init__(self, attrs_as_metadata: Optional[Set] = None) -> None:
-        """Init params."""
+    def __init__(self, split_by_layout: bool = False, config_overwrite: Optional[List] = None,
+                 extra_info: Optional[Set] = None ) -> None:
+        """Init params.
+
+        Args:
+            split_by_layout (bool): If `True` will use layout section detected by deepdoctection's layout models to
+                                    create documents.
+                                    For the default settings this will be `text`, `title`, `list` and `table`.
+                                    Otherwise, it will generate one document per page.
+            config_overwrite (List): Overwrite the deepdoctection default configuration, e.g.
+                                     ['USE_TABLE_SEGMENTATION=False', 'USE_OCR=False'].
+            extra_info (Set): Adding metadata to a document. Available attributes depend on `split_by_layout`.
+                              When creating Documents on page level, then available will be:
+                              - `file_name`: Original name of PDF-document/ image file
+                              - `location`: Full path to the original document
+                              - `document_id`: uuid derived from the location
+                              - `page_number`: page number in multipage document. Defaults to 1 for a single image file
+                              - `image_id`: uuid for a single page. Coincides with `document_id` for single page files
+                              When using layout sections as documents, then all attributes on page level are available
+                              as well as:
+                              - `annotation_id`: uuid for layout section
+                              - `reading_order`: reading order position of layout section within page scope
+                              - `category_name`: type of layout section described above
+        """
         import deepdoctection as dd
 
-        self.analyzer = dd.get_dd_analyzer()
-        self.attrs_as_metadata = attrs_as_metadata or set()
+        self.analyzer = dd.get_dd_analyzer(config_overwrite=config_overwrite)
+        self.split_by_layout = split_by_layout
+        self.extra_info_attrs = extra_info or set()
+        self._key_to_chunk_position = {"document_id": 0,
+                                       "image_id": 1,
+                                       "page_number": 2,
+                                       "annotation_id": 3,
+                                       "reading_order": 4,
+                                       "category_name": 5
+                                       }
 
-    def load_data(
-        self, file: Path, extra_info: Optional[Dict] = None
-    ) -> List[Document]:
-        """Parse file."""
+    def load_data(self, file: Path) -> List[Document]:
+        """Parse file or directory with scans."""
         df = self.analyzer.analyze(path=str(file))
         df.reset_state()
-        doc = iter(df)
         result_docs = []
-        for page in doc:
-            doc_text = page.text
-            extra_info = {
-                k: getattr(page, k) for k in self.attrs_as_metadata if hasattr(page, k)
-            }
-            result_docs.append(Document(text=doc_text, extra_info=extra_info))
+        for page in df:
+            if self.split_by_layout:
+                result_docs.extend(Document(text=chunk[6],
+                                            extra_info={k: chunk[self._key_to_chunk_position[k]] for k in
+                                                        self.extra_info_attrs})
+                                   for chunk in page.chunks)
+            else:
+                extra_info = {k: getattr(page, k) for k in self.extra_info_attrs if hasattr(page, k)}
+                result_docs.append(Document(text=page.text, extra_info=extra_info))
         return result_docs

--- a/llama_hub/file/deepdoctection/requirements.txt
+++ b/llama_hub/file/deepdoctection/requirements.txt
@@ -1,2 +1,2 @@
-deepdoctection[pt]
+deepdoctection
 torch


### PR DESCRIPTION
Hi!

After spending quite a while extending deepdoctection to build a flexible data loader for PDFs and image scans I have taken the opportunity to extend the functionality of `DeepDoctectionReader`:

- You can build `Document`s by extracting the full text page-wise or by using layout sections like title, text, tables. 
- Adding metadata to `Document`s was already possible, I just made it a bit more clear, what type of metadata can be added.
- Customizing the loader. You can switch between three different OCR tools (Tesseract, DocTr, and AWS Textract), can do some filtering (e.g. excluding tables) and a lot more.

To give a little more insight about what is possible, I added some sections to the README. 

Finally, I changed the `requirements.txt`, so that users who just get started have a minimal setting and a low entry barrier.   
