### PR TITLE
patch document in wordpress

### DIFF
--- a/llama_hub/wordpress/base.py
+++ b/llama_hub/wordpress/base.py
@@ -51,7 +51,7 @@ class WordpressReader(BaseReader):
 
             results.append(
                 Document(
-                    body,
+                    text=body,
                     extra_info=extra_info,
                 )
             )


### PR DESCRIPTION
The `Document` initialization was missing `text=`, causing errors as seen in #360 