### PR TITLE
UTF-8 encode and decode for gmail

### DIFF
--- a/llama_hub/tools/gmail/base.py
+++ b/llama_hub/tools/gmail/base.py
@@ -161,14 +161,14 @@ class GmailToolSpec(BaseToolSpec):
         from bs4 import BeautifulSoup
 
         try:
-            body = base64.urlsafe_b64decode(message["raw"].encode("ASCII"))
+            body = base64.urlsafe_b64decode(message["raw"].encode("utf-8"))
             mime_msg = email.message_from_bytes(body)
 
             # If the message body contains HTML, parse it with BeautifulSoup
             if "text/html" in mime_msg:
                 soup = BeautifulSoup(body, "html.parser")
                 body = soup.get_text()
-            return body.decode("ascii")
+            return body.decode("utf-8")
         except Exception as e:
             raise Exception("Can't parse message body" + str(e))
 


### PR DESCRIPTION
It's unsafe to assume emails are pure ascii and resolves #471 