### PR TITLE
Enhance PDFReader to accept File object as well, in addition to a path string

### DIFF
--- a/llama_hub/file/pdf/base.py
+++ b/llama_hub/file/pdf/base.py
@@ -37,7 +37,7 @@ class PDFReader(BaseReader):
                 # Extract the text from the page
                 page_text = pdf.pages[page].extract_text()
                 page_label = pdf.page_labels[page]
-                metadata = {"page_label": page_label, "file_name": file.name if isinstance(file, Path) else file.name}
+                metadata = {"page_label": page_label, "file_name": file.name}
 
                 if extra_info is not None:
                     metadata.update(extra_info)


### PR DESCRIPTION
This PR extends the capabilities of the **`PDFReader`** in the **`llama_index.readers`** module to accept multiple input types, specifically: a file object, a string representation of a path, or a **`Path`** object directly.

### **Motivation:**

While working with a web app, I found it challenging to use the **`PDFReader`** because I couldn't save files onto the local file system, which necessitated the ability to pass in an in-memory file object. This got me thinking about the varied use-cases and environments other users might be dealing with, and how this enhancement could benefit everyone.

### **Benefits:**

1. **Flexibility:** With this change, users can seamlessly switch between different ways of passing files based on their specific requirements without having to refactor or add file handling logic.
2. **Web Applications:** For developers using **`llama-hub`** in cloud environments or web applications where direct file system access might be restricted, passing in-memory file objects becomes straightforward.
3. **Readability and Clean Code:** By abstracting away the file handling logic inside **`PDFReader`**, user code becomes cleaner, more readable, and focused on business logic.

### **Changes:**

- Updated the **`load_data`** function of **`PDFReader`** to handle three types of file inputs.
- Added type hints to make it clear what types of inputs are supported.

I sincerely believe this change can make the library even more user-friendly and adaptable to various scenarios. Feedback, suggestions, or further improvement ideas are most welcome!

Note: Other File readers (DocX) already support File objects as input, so no change required there.