### PR TITLE
fix: 🚑️ remove app id and secret from code

### DIFF
--- a/llama_hub/feishu_docs/base.py
+++ b/llama_hub/feishu_docs/base.py
@@ -1,6 +1,7 @@
 """Feishu docs reader."""
 import json
 import time
+import os
 
 import requests
 from typing import List
@@ -103,9 +104,9 @@ class FeishuDocsReader(BaseReader):
 
 
 if __name__ == "__main__":
-    app_id = "cli_a4d536f6a738d00b"
-    app_secret = "HL29tOCwRHw390Cr6jQBBdFjmYlTJt1e"
+    app_id = os.environ.get("FEISHU_APP_ID")
+    app_secret = os.environ.get("FEISHU_APP_SECRET")
     reader = FeishuDocsReader(app_id, app_secret)
     print(
-        reader.load_data(document_ids=['HIH2dHv21ox9kVxjRuwc1W0jnkf'])
+        reader.load_data(document_ids=[os.environ.get("FEISHU_DOC_ID")])
     )


### PR DESCRIPTION
There were some still valid credentials ! Here is an example of how to avoid hard-coding credentials, but the most important now is to revoke your credentials :