### PR TITLE
Fix BaseGithubClient and _generate_documents

### DIFF
--- a/llama_hub/github_repo/base.py
+++ b/llama_hub/github_repo/base.py
@@ -369,7 +369,7 @@ class GithubRepositoryReader(BaseReader):
     async def _generate_documents(
         self,
         blobs_and_paths: List[Tuple[GitTreeResponseModel.GitTreeObject, str]],
-        id: Optional[str],
+        id: str = "",
     ) -> List[Document]:
         """
         Generate documents from a list of blobs and their full paths.

--- a/llama_hub/github_repo/github_client.py
+++ b/llama_hub/github_repo/github_client.py
@@ -193,7 +193,8 @@ class BaseGithubClient(Protocol):
         self,
         owner: str,
         repo: str,
-        branch_name: str,
+        branch: Optional[str],
+        branch_name: Optional[str],
     ) -> GitBranchResponseModel:
         ...
 
@@ -322,7 +323,11 @@ class GithubClient:
             return response
 
     async def get_branch(
-        self, owner: str, repo: str, branch: str
+        self,
+        owner: str,
+        repo: str,
+        branch: Optional[str] = None,
+        branch_name: Optional[str] = None,
     ) -> GitBranchResponseModel:
         """
         Get information about a branch. (Github API endpoint: getBranch).
@@ -338,6 +343,11 @@ class GithubClient:
         Examples:
             >>> branch_info = client.get_branch("owner", "repo", "branch")
         """
+        if branch is None:
+            if branch_name is None:
+                raise ValueError("Either branch or branch_name must be provided.")
+            branch = branch_name
+
         return GitBranchResponseModel.from_json(
             (
                 await self.request(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ typing_extensions = "4.5.0"
 types-requests = "2.28.11.8"
 black = "22.12.0"
 isort = "5.11.4"
-
+pytest-asyncio = "^0.21.1"
 
 [build-system]
 requires = ["poetry>=0.12", "poetry-core>=1.0.0"]

--- a/tests/tests_github_repo/test_github_client.py
+++ b/tests/tests_github_repo/test_github_client.py
@@ -70,10 +70,11 @@ async def test_github_client(github_client):
         ("Makefile", "blob"),
         (".gitignore", "blob"),
         ("tests", "tree"),
-        ("llama_hub", "tree"),
+        ("loader_hub", "tree"),
         (".github", "tree"),
     ]
     # check if the first depth of the tree has the expected files. All the expected files should be in the first depth of the tree and vice versa
+    print(tree_data.tree)
     assert len(tree_data.tree) == len(
         expected_files_in_first_depth_of_the_tree
     ), "The number of files in the first depth of the tree is incorrect"
@@ -133,6 +134,25 @@ isort==5.11.4
     ):
         assert dbc[0] == dbc[1], f"{dbc[0]} is not equal to {dbc[1]}"
 
+@pytest.mark.asyncio
+async def test_github_client_get_branch_parameter_exception(github_client):
+    branch_data = await github_client.get_branch(
+        owner="emptycrown",
+        repo="llama-hub",
+        branch="main",
+    )
+    assert branch_data.name == "main"
+    branch_data = await github_client.get_branch(
+        owner="emptycrown",
+        repo="llama-hub",
+        branch_name="main",
+    )
+    assert branch_data.name == "main"
+    with pytest.raises(ValueError):
+        await github_client.get_branch(
+            owner="emptycrown",
+            repo="llama-hub",
+        )
 
 class TestGithubRepositoryReader(unittest.TestCase):
     def setUp(self):

--- a/tests/tests_github_repo/test_github_client.py
+++ b/tests/tests_github_repo/test_github_client.py
@@ -60,7 +60,6 @@ async def test_github_client(github_client):
         == f"https://api.github.com/repos/{owner}/{repo}/git/trees/{commit_data.commit.tree.sha}"
     ), "Tree url is incorrect"
     assert tree_data.sha == commit_data.commit.tree.sha, "Tree sha is incorrect"
-    print(tree_data.tree[0].sha)
     assert 1 == 1
 
     # test get_blob
@@ -74,7 +73,6 @@ async def test_github_client(github_client):
         (".github", "tree"),
     ]
     # check if the first depth of the tree has the expected files. All the expected files should be in the first depth of the tree and vice versa
-    print(tree_data.tree)
     assert len(tree_data.tree) == len(
         expected_files_in_first_depth_of_the_tree
     ), "The number of files in the first depth of the tree is incorrect"

--- a/tests/tests_github_repo/test_github_reader.py
+++ b/tests/tests_github_repo/test_github_reader.py
@@ -383,7 +383,7 @@ async def test__generate_documents():
 
     github_client.get_blob = AsyncMock(side_effect=get_blob_side_effect)
 
-    documents = await reader._generate_documents(blobs_and_paths)
+    documents = await reader._generate_documents(blobs_and_paths, id="1234")
 
     assert (
         github_client.get_blob.await_count == 5
@@ -409,6 +409,7 @@ async def test__generate_documents():
             extra_info={
                 "file_path": "file1.py",
                 "file_name": "file1.py",
+                "url": "https://github.com/owner/repo/blob/1234/file1.py",
             },
         ),
         Document(
@@ -416,6 +417,7 @@ async def test__generate_documents():
             extra_info={
                 "file_path": "folder1/file2.ts",
                 "file_name": "file2.ts",
+                "url": "https://github.com/owner/repo/blob/1234/folder1/file2.ts",
             },
         ),
         Document(
@@ -423,6 +425,7 @@ async def test__generate_documents():
             extra_info={
                 "file_path": "folder1/folder2/file3.rs",
                 "file_name": "file3.rs",
+                "url": "https://github.com/owner/repo/blob/1234/folder1/folder2/file3.rs",
             },
         ),
         Document(
@@ -430,6 +433,7 @@ async def test__generate_documents():
             extra_info={
                 "file_path": "folder1/folder2/folder3/file4.cc",
                 "file_name": "file4.cc",
+                "url": "https://github.com/owner/repo/blob/1234/folder1/folder2/folder3/file4.cc",
             },
         ),
     ]


### PR DESCRIPTION
* Add `branch` parameter to `get_branch` definition due to `GithubClient` implementation `get_branch` definition making use of `branch_name` as opposed to `branch`. This issue is most prevelent when type checker runs and they do not match
* Throw exception if neither `branch` or `branch_name` is not defined. Potentionally could also add deprecation messaging.
* Fix definition of `_generate_documents` id parameter. Default to empty string `""` as `os.path.join` will omit an empty string from the path list, but will fail on `None`
* Fix `test__generate_documents` `url` value likely added after test addition
* Fix `test_github_client` test to `loader_hub` as `llama_hub` did not exist at commit sha selected in test
* Add `pytest-asyncio` dev dependency as this is required for async tests in `test_github_client` that make use of the `@pytest.mark.asyncio` decorator

_Note_: Tests in `tests_github_repo` are currently all skipped unless the skip declaration is removed or commented out from `tests_github_repo/__init__.py`