### PR TITLE
Add page id to extra_info

### DIFF
--- a/llama_hub/confluence/base.py
+++ b/llama_hub/confluence/base.py
@@ -289,7 +289,7 @@ class ConfluenceReader(BaseReader):
             attachment_texts
         )
         return Document(
-            text=text, doc_id=page["id"], extra_info={"title": page["title"]}
+            text=text, doc_id=page["id"], extra_info={"title": page["title"], "page_id": page["id"]}
         )
 
     def process_attachment(self, page_id):

--- a/llama_hub/confluence/base.py
+++ b/llama_hub/confluence/base.py
@@ -289,7 +289,9 @@ class ConfluenceReader(BaseReader):
             attachment_texts
         )
         return Document(
-            text=text, doc_id=page["id"], extra_info={"title": page["title"], "page_id": page["id"]}
+            text=text,
+            doc_id=page["id"],
+            extra_info={"title": page["title"], "page_id": page["id"]},
         )
 
     def process_attachment(self, page_id):

--- a/tests/tests_confluence/test_confluence_reader.py
+++ b/tests/tests_confluence/test_confluence_reader.py
@@ -146,9 +146,9 @@ class TestConfluenceReader:
         assert len(documents) == 2
         assert all(isinstance(doc, Document) for doc in documents)
         assert documents[0].doc_id == "123"
-        assert documents[0].extra_info == {"title": "Page 123"}
+        assert documents[0].extra_info == {"title": "Page 123", "page_id": "123"}
         assert documents[1].doc_id == "456"
-        assert documents[1].extra_info == {"title": "Page 456"}
+        assert documents[1].extra_info == {"title": "Page 456", "page_id": "456"}
 
         assert mock_confluence.get_page_by_id.call_count == 2
 
@@ -205,9 +205,9 @@ class TestConfluenceReader:
         assert len(documents) == 2
         assert all(isinstance(doc, Document) for doc in documents)
         assert documents[0].doc_id == "123"
-        assert documents[0].extra_info == {"title": "Page 123"}
+        assert documents[0].extra_info == {"title": "Page 123", "page_id": "123"}
         assert documents[1].doc_id == "456"
-        assert documents[1].extra_info == {"title": "Page 456"}
+        assert documents[1].extra_info == {"title": "Page 456", "page_id": "456"}
 
         assert mock_confluence.get_page_by_id.call_count == 0
         assert mock_confluence.get_all_pages_by_label.call_count == 0
@@ -256,9 +256,9 @@ class TestConfluenceReader:
         assert len(documents) == 2
         assert all(isinstance(doc, Document) for doc in documents)
         assert documents[0].doc_id == "123"
-        assert documents[0].extra_info == {"title": "Page 123"}
+        assert documents[0].extra_info == {"title": "Page 123", "page_id": "123"}
         assert documents[1].doc_id == "456"
-        assert documents[1].extra_info == {"title": "Page 456"}
+        assert documents[1].extra_info == {"title": "Page 456", "page_id": "456"}
 
         assert mock_confluence.get_page_by_id.call_count == 0
         assert mock_confluence.get_all_pages_by_label.call_count == 0


### PR DESCRIPTION
# Description
Add page id info to metadata, having title is problematic as it can change but page id will be unique and can be used by retriever. 

## Type of Change

Please delete options that are not relevant.

- [x] Smaller change

# How Has This Been Tested?
Have tested this locally and should help with having extra info for stored document index. 
- [ x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes