### PR TITLE
break loop if API error

### DIFF
--- a/llama_hub/slack/base.py
+++ b/llama_hub/slack/base.py
@@ -100,6 +100,7 @@ class SlackReader(BaseReader):
                     time.sleep(int(e.response.headers["retry-after"]))
                 else:
                     logger.error("Error parsing conversation replies: {}".format(e))
+                    break
 
         return "\n\n".join(messages_text)
 
@@ -158,6 +159,7 @@ class SlackReader(BaseReader):
                     time.sleep(int(e.response.headers["retry-after"]))
                 else:
                     logger.error("Error parsing conversation replies: {}".format(e))
+                    break
 
         return (
             "\n\n".join(result_messages)


### PR DESCRIPTION
# Description
When the API resulted in error, error got logged but the while loop continued infinitely.
Added a break to fix this.
https://github.com/emptycrown/llama-hub/issues/545

## Type of Change
- [x] Smaller change

## How Has This Been Tested?
Have tested this locally
- [x] I stared at the code and made sure it makes sense

## Suggested Checklist:
 I have performed a self-review of my own code
 New and existing unit tests pass locally with my changes

