### PR TITLE
fix: remove isort due using black and add a new checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,3 +30,4 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
+- [ ] I ran `make format; make lint` to appease the lint gods

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@
 
 format:
 	black .
-	isort .
-
 lint:
 	ruff check .
 	black --check .


### PR DESCRIPTION
# Description

Remove `isort` since `black` library is already being used, and it's causing conflicts

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix / Smaller change
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense