### PR TITLE
fix: PyMuPDF Reader broken

### DIFF
--- a/llama_hub/file/pymu_pdf/README.md
+++ b/llama_hub/file/pymu_pdf/README.md
@@ -13,7 +13,7 @@ from llama_index import download_loader
 PyMuPDFReader = download_loader("PyMuPDFReader")
 
 loader = PyMuPDFReader()
-documents = loader.load(file_path=Path('./article.pdf'), metadata=True)
+documents = loader.load_data(file_path=Path('./article.pdf'), metadata=True)
 ```
 
 This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/jerryjliu/gpt_index/tree/main/gpt_index) and/or subsequently used as a Tool in a [LangChain](https://github.com/hwchase17/langchain) Agent. See [here](https://github.com/emptycrown/llama-hub/tree/main) for examples.

--- a/llama_hub/file/pymu_pdf/base.py
+++ b/llama_hub/file/pymu_pdf/base.py
@@ -9,6 +9,14 @@ from llama_index.readers.schema.base import Document
 class PyMuPDFReader(BaseReader):
     """Read PDF files using PyMuPDF library."""
 
+    def load_data(
+        self,
+        file_path: Union[Path, str],
+        extra_info: Optional[Dict] = None
+    ) -> List[Document]:
+        """Loads list of documents from PDF file and also accepts extra information in dict format."""
+        return self.load(file_path, metadata=True, extra_info=extra_info)
+
     def load(
         self,
         file_path: Union[Path, str],

--- a/llama_hub/file/pymu_pdf/base.py
+++ b/llama_hub/file/pymu_pdf/base.py
@@ -10,9 +10,7 @@ class PyMuPDFReader(BaseReader):
     """Read PDF files using PyMuPDF library."""
 
     def load_data(
-        self,
-        file_path: Union[Path, str],
-        extra_info: Optional[Dict] = None
+        self, file_path: Union[Path, str], extra_info: Optional[Dict] = None
     ) -> List[Document]:
         """Loads list of documents from PDF file and also accepts extra information in dict format."""
         return self.load(file_path, metadata=True, extra_info=extra_info)

--- a/llama_hub/file/pymu_pdf/base.py
+++ b/llama_hub/file/pymu_pdf/base.py
@@ -10,10 +10,13 @@ class PyMuPDFReader(BaseReader):
     """Read PDF files using PyMuPDF library."""
 
     def load_data(
-        self, file_path: Union[Path, str], extra_info: Optional[Dict] = None
+        self,
+        file_path: Union[Path, str],
+        metadata: bool = True,
+        extra_info: Optional[Dict] = None,
     ) -> List[Document]:
         """Loads list of documents from PDF file and also accepts extra information in dict format."""
-        return self.load(file_path, metadata=True, extra_info=extra_info)
+        return self.load(file_path, metadata=metadata, extra_info=extra_info)
 
     def load(
         self,


### PR DESCRIPTION
# Description

PyMuPDF with SimpleDirectoryReader `file_extractor` wasn't working since it uses `load_data()` instead of `load()`

Fixes https://github.com/emptycrown/llama-hub/issues/509

## Type of Change

Please delete options that are not relevant.

- [ ] New Loader/Tool
- [x] Bug fix / Smaller change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Added new unit/integration tests
- [ ] Added new notebook (that tests end-to-end)
- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [ ] I have added a library.json file if a new loader/tool was added
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods