### PR TITLE
Add JSONL functionality to JSONReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Changes from llama_index/PR#7906 (#557)
 - fix: sql_wrapper utilities (#558)
 - Adding functionality for AsanaReader (#386)
+- Add JSONL functionality to JSONReader (#552)
 
 ## [v0.0.34] - 2023-09-27
 

--- a/llama_hub/file/json/README.md
+++ b/llama_hub/file/json/README.md
@@ -1,10 +1,12 @@
 # JSON Loader
 
-This loader extracts the text in a formatted manner from a JSON file. A single local file is passed in each time you call `load_data`.
+This loader extracts the text in a formatted manner from a JSON or JSONL file. A single local file is passed in each time you call `load_data`.
 
 ## Usage
 
-To use this loader, you need to pass in a `Path` to a local file.
+To use this loader, you need to pass in a `Path` to a local file and set the `is_jsonl` parameter to `True` for JSONL files or `False` for regular JSON files.
+
+### JSON
 
 ```python
 from pathlib import Path
@@ -14,6 +16,18 @@ JSONReader = download_loader("JSONReader")
 
 loader = JSONReader()
 documents = loader.load_data(Path('./data.json'))
+```
+
+### JSONL
+
+```python
+from pathlib import Path
+from llama_index import download_loader
+
+JSONReader = download_loader("JSONReader")
+
+loader = JSONReader()
+documents = loader.load_data(Path('./data.jsonl'), is_jsonl=True)
 ```
 
 This loader is designed to be used as a way to load data into [LlamaIndex](https://github.com/jerryjliu/gpt_index/tree/main/gpt_index) and/or subsequently used as a Tool in a [LangChain](https://github.com/hwchase17/langchain) Agent. See [here](https://github.com/emptycrown/llama-hub/tree/main) for examples.

--- a/llama_hub/file/json/base.py
+++ b/llama_hub/file/json/base.py
@@ -51,13 +51,27 @@ class JSONReader(BaseReader):
         self.levels_back = levels_back
 
     def load_data(
-        self, file: Path, extra_info: Optional[Dict] = None
+        self, file: Path, is_jsonl: Optional[bool] = False, extra_info: Optional[Dict] = None
     ) -> List[Document]:
-        """Load data from the input file."""
+        """Load data from the input file.
+        
+        Args:
+            file (Path): Path to the input file.
+            is_jsonl (Optional[bool]): If True, indicates that the file is in JSONL format. Defaults to False.
+            extra_info (Optional[Dict]): Additional information. Default is None.
+            
+        Returns:
+            List[Document]: List of documents.
+        """
         if not isinstance(file, Path):
             file = Path(file)
-        with open(file, "r") as f:
-            data = json.load(f)
+        with open(file, "r") as f:  
+            data = []
+            if is_jsonl:
+                for line in f:
+                    data.append(json.loads(line.strip()))
+            else:
+                data = json.load(f)
             documents = []
             for json_object in data:
                 if self.levels_back is None:

--- a/llama_hub/file/json/base.py
+++ b/llama_hub/file/json/base.py
@@ -51,21 +51,24 @@ class JSONReader(BaseReader):
         self.levels_back = levels_back
 
     def load_data(
-        self, file: Path, is_jsonl: Optional[bool] = False, extra_info: Optional[Dict] = None
+        self,
+        file: Path,
+        is_jsonl: Optional[bool] = False,
+        extra_info: Optional[Dict] = None,
     ) -> List[Document]:
         """Load data from the input file.
-        
+
         Args:
             file (Path): Path to the input file.
             is_jsonl (Optional[bool]): If True, indicates that the file is in JSONL format. Defaults to False.
             extra_info (Optional[Dict]): Additional information. Default is None.
-            
+
         Returns:
             List[Document]: List of documents.
         """
         if not isinstance(file, Path):
             file = Path(file)
-        with open(file, "r") as f:  
+        with open(file, "r") as f:
             data = []
             if is_jsonl:
                 for line in f:


### PR DESCRIPTION
# Description

With the growing adoption of JSONL for large datasets due to its line-delimited nature, there was a need to expand the capabilities of our existing JSONReader. Previously, the JSONReader was designed solely to handle standard JSON files. This PR addresses that limitation by adding functionality to JSONReader to handle JSONL files. This enhancement ensures that users can now work with both JSON and JSONL files without the need for any additional loaders or configurations. If required we can have separate loaders too to make them modular but the core logic for them remains the same.