### PR TITLE
Changes from llama_index/PR#7906

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add page id to extra_info (#542) 
 - Update: Readme with corrected example url for Playgrounds_subgraph_connector tool (#551)
 - add url and status to confluence loader document (#553)
+- Changes from llama_index/PR#7906 (#557)
 
 ## [v0.0.34] - 2023-09-27
 

--- a/llama_hub/discord/base.py
+++ b/llama_hub/discord/base.py
@@ -68,7 +68,8 @@ async def read_channel(
     client = CustomClient(intents=intents)
     await client.start(discord_token)
 
-    # Wraps each message in a Document containing the text as well as some useful metadata properties.
+    # Wraps each message in a Document containing the text \
+    # as well as some useful metadata properties.
     return list(
         map(
             lambda msg: Document(

--- a/llama_hub/discord/base.py
+++ b/llama_hub/discord/base.py
@@ -1,19 +1,27 @@
-"""Discord reader."""
+"""Discord reader.
+
+Note: this file is named discord_reader.py to avoid conflicts with the
+discord.py module.
+
+"""
 
 import asyncio
 import logging
 import os
 from typing import List, Optional
 
-from llama_index.readers.base import BaseReader
-from llama_index.readers.schema.base import Document
+from llama_index.readers.base import BasePydanticReader
+from llama_index.schema import Document
 
 logger = logging.getLogger(__name__)
 
 
 async def read_channel(
-    discord_token: str, channel_id: int, limit: Optional[int], oldest_first: bool
-) -> str:
+    discord_token: str,
+    channel_id: int,
+    limit: Optional[int],
+    oldest_first: bool,
+) -> List[Document]:
     """Async read channel.
 
     Note: This is our hack to create a synchronous interface to the
@@ -28,7 +36,7 @@ async def read_channel(
     class CustomClient(discord.Client):
         async def on_ready(self) -> None:
             try:
-                print(f"{self.user} has connected to Discord!")
+                logger.info(f"{self.user} has connected to Discord!")
                 channel = client.get_channel(channel_id)
                 # only work for text channels for now
                 if not isinstance(channel, discord.TextChannel):
@@ -40,7 +48,6 @@ async def read_channel(
                 thread_dict = {}
                 for thread in channel.threads:
                     thread_dict[thread.id] = thread
-
                 async for msg in channel.history(
                     limit=limit, oldest_first=oldest_first
                 ):
@@ -52,7 +59,7 @@ async def read_channel(
                         ):
                             messages.append(thread_msg)
             except Exception as e:
-                print("Encountered error: " + str(e))
+                logger.error("Encountered error: " + str(e))
             finally:
                 await self.close()
 
@@ -61,12 +68,24 @@ async def read_channel(
     client = CustomClient(intents=intents)
     await client.start(discord_token)
 
-    msg_txt_list = [m.content for m in messages]
+    # Wraps each message in a Document containing the text as well as some useful metadata properties.
+    return list(
+        map(
+            lambda msg: Document(
+                text=msg.content,
+                metadata={
+                    "message_id": msg.id,
+                    "username": msg.author.name,
+                    "created_at": msg.created_at,
+                    "edited_at": msg.edited_at,
+                },
+            ),
+            messages,
+        )
+    )
 
-    return "\n\n".join(msg_txt_list)
 
-
-class DiscordReader(BaseReader):
+class DiscordReader(BasePydanticReader):
     """Discord reader.
 
     Reads conversations from channels.
@@ -77,8 +96,17 @@ class DiscordReader(BaseReader):
 
     """
 
+    is_remote: bool = True
+    discord_token: str
+
     def __init__(self, discord_token: Optional[str] = None) -> None:
         """Initialize with parameters."""
+        try:
+            import discord  # noqa: F401
+        except ImportError:
+            raise ImportError(
+                "`discord.py` package not found, please run `pip install discord.py`"
+            )
         if discord_token is None:
             discord_token = os.environ["DISCORD_TOKEN"]
             if discord_token is None:
@@ -87,11 +115,16 @@ class DiscordReader(BaseReader):
                     "variable `DISCORD_TOKEN`."
                 )
 
-        self.discord_token = discord_token
+        super().__init__(discord_token=discord_token)
+
+    @classmethod
+    def class_name(cls) -> str:
+        """Get the name identifier of the class."""
+        return "DiscordReader"
 
     def _read_channel(
         self, channel_id: int, limit: Optional[int] = None, oldest_first: bool = True
-    ) -> str:
+    ) -> List[Document]:
         """Read channel."""
         result = asyncio.get_event_loop().run_until_complete(
             read_channel(
@@ -125,17 +158,15 @@ class DiscordReader(BaseReader):
                     f"Channel id {channel_id} must be an integer, "
                     f"not {type(channel_id)}."
                 )
-            channel_content = self._read_channel(
+            channel_documents = self._read_channel(
                 channel_id, limit=limit, oldest_first=oldest_first
             )
-            results.append(
-                Document(text=channel_content, extra_info={"channel": channel_id})
-            )
+            results += channel_documents
         return results
 
 
 if __name__ == "__main__":
     reader = DiscordReader()
-    print("initialized reader")
+    logger.info("initialized reader")
     output = reader.load_data(channel_ids=[1057178784895348746], limit=10)
-    print(output)
+    logger.info(output)


### PR DESCRIPTION
> had a rebase issue with the original (https://github.com/emptycrown/llama-hub/pull/555) but thanks for the support @BLopata

# Description
Modifies the `load_data` method of the Discord Reader class with additional metadata properties added to the Document containing the message.

This change is needed for users who wish to query information about the users and allows for further advanced filtering (such as NSFW content, among others). This change requires no dependency changes.

Note: We view this is a starting point. If other use cases require additional metadata, it can be extended to support that.

[llama_index PR](https://github.com/jerryjliu/llama_index/pull/7906)

Fixes # (issue)

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Ran a modified version of the [Discord Reader Demo](https://gpt-index.readthedocs.io/en/stable/examples/data_connectors/DiscordDemo.html) locally and queried the index/engine for a list of users who sent messages in the specified channel (query: `list all users who posted to the channel` produced an output similar to `There is no information provided about the users who posted ideas to the channel.` without the changes, and produced an accurate list when the metadata was provided by including the parsing logic.

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I ran `make format; make lint` to appease the lint gods
