### PR TITLE
fix: credentials path and readme improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### New Features
+
+### Smaller Features + Bug Fixes
+- fix: credentials path and readme improvement (#567)
+
 ### [v0.0.35] - 2023-10-05
 - Loader for Macrometa GDN (#484)
 - adding boto3 minio doc loader (#497)

--- a/llama_hub/google_drive/README.md
+++ b/llama_hub/google_drive/README.md
@@ -25,7 +25,7 @@ We need `credentials.json` file to use this reader.
 1. You need to create a service account folllowing the steps mentioned [here](https://cloud.google.com/iam/docs/keys-create-delete)
 2. Get your json file and rename to `credentials.json` and move to the project root
 
-> Note: If you are not using Google Workspaces (formerly GSuite), You'll need to share your document making it public, or invting your service account as an reader/editor of the folder or file.
+> Note: If you are not using Google Workspaces (formerly GSuite), You'll need to share your document making it public, or inviting your service account as an reader/editor of the folder or file.
 
 Finally, make sure you enable "Google Drive API" in the console of your Google App.
 

--- a/llama_hub/google_drive/README.md
+++ b/llama_hub/google_drive/README.md
@@ -20,10 +20,12 @@ You can also filter the files by the mimeType e.g.: `mime_types=["application/vn
 
 ## Usage
 
-We need `credentials.json` and `client_secrets.json` files to use this reader.
+We need `credentials.json` file to use this reader.
 
-1. You need to get your `credentials.json` file by following the steps mentioned [here](https://developers.google.com/drive/api/v3/quickstart/python)
-2. Create duplicate file of `credentials.json` with name `client_secrets.json` which will be used by pydrive for downloading files.
+1. You need to create a service account folllowing the steps mentioned [here](https://cloud.google.com/iam/docs/keys-create-delete)
+2. Get your json file and rename to `credentials.json` and move to the project root
+
+> Note: If you are not using Google Workspaces (formerly GSuite), You'll need to share your document making it public, or invting your service account as an reader/editor of the folder or file.
 
 Finally, make sure you enable "Google Drive API" in the console of your Google App.
 

--- a/llama_hub/google_drive/base.py
+++ b/llama_hub/google_drive/base.py
@@ -74,9 +74,9 @@ class GoogleDriveReader(BaseReader):
         creds = None
         if os.path.exists(self.token_path):
             creds = Credentials.from_authorized_user_file(self.token_path, SCOPES)
-        elif os.path.exists(self.service_account_path):
+        elif os.path.exists(self.credentials_path):
             creds = service_account.Credentials.from_service_account_file(
-                self.service_account_path, scopes=SCOPES
+                self.credentials_path, scopes=SCOPES
             )
             gauth = GoogleAuth()
             gauth.credentials = creds


### PR DESCRIPTION
# Description

Google Drive Reader wasn't working as it should, not using the credentials file, and instructions weren't updated to use service accounts.

Fixes # ([issue](https://github.com/emptycrown/llama-hub/issues/536))

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix / Smaller change

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] I stared at the code and made sure it makes sense

# Suggested Checklist:

- [x] I have made corresponding changes to the documentation
- [x] I ran `make format; make lint` to appease the lint gods